### PR TITLE
feat(pool): add pooling, switching, and opencode sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,45 @@
 - Shows subscription renewal countdown (when the subscription renews or expires)
 - Highlights accounts with exhausted weekly limits
 - Recommends which account to use first (prioritizes by weekly usage pressure)
+- Creates and manages a default OpenAI account pool for auto-switching
+- Runs child tools (like opencode) with pool-selected account/session env
 - Renders human-readable or JSON output
 
 ## Install
 
 ```bash
 go install github.com/bnema/openai-accounts-cli/cmd/oa@latest
+```
+
+### Add `oa` to your `PATH`
+
+`go install` places the binary in `$(go env GOPATH)/bin` (usually `$HOME/go/bin`) unless `GOBIN` is set.
+
+- `bash`
+  ```bash
+  echo 'export PATH="$HOME/go/bin:$PATH"' >> ~/.bashrc
+  source ~/.bashrc
+  ```
+- `zsh`
+  ```bash
+  echo 'export PATH="$HOME/go/bin:$PATH"' >> ~/.zshrc
+  source ~/.zshrc
+  ```
+- `fish`
+  ```fish
+  fish_add_path $HOME/go/bin
+  ```
+- `PowerShell`
+  ```powershell
+  $goBin = (go env GOPATH) + "\\bin"
+  [Environment]::SetEnvironmentVariable("Path", $env:Path + ";$goBin", "User")
+  ```
+
+Verify installation:
+
+```bash
+which oa
+oa version
 ```
 
 ### Auth setup
@@ -36,7 +69,34 @@ oa usage --account 1
 
 # JSON output
 oa status --account 1 --json
+
+# Activate default pool (auto-discovers OpenAI accounts)
+oa pool activate
+
+# Show pool status
+oa pool status
+
+# Switch manually to next eligible account
+oa pool next
+
+# Switch to specific account by ID or name
+oa pool switch --account 2
+
+# Interactive switch (shows numbered eligible accounts)
+oa pool switch
+
+# Run opencode with auto-selected account from pool
+oa run --pool default-openai -- opencode
+
+# Optional: isolate continuity per terminal/window
+OA_WINDOW_FINGERPRINT=project-a-window-1 oa run --pool default-openai -- opencode
 ```
+
+### Switching behavior
+
+- `oa pool switch` and `oa pool next` update the selected pool account and sync `~/.local/share/opencode/auth.json` immediately.
+- `oa usage` marks the selected account with `(Active)`.
+- If opencode is already running, restart it (or launch again with `oa run -- opencode`) to use the newly synced auth in that process.
 
 ## Commands
 
@@ -47,6 +107,8 @@ oa status --account 1 --json
 | `oa usage [--account <id>] [--json]` | Fetch usage limits and subscription renewal info (all accounts if no ID specified) |
 | `oa status [--account <id>] [--json]` | Alias for usage |
 | `oa account list` | List accounts |
+| `oa pool activate\|deactivate\|status\|next\|switch` | Manage default OpenAI pool state and selected account |
+| `oa run --pool <id> -- <cmd>` | Run a command with pool-selected account and session env |
 | `oa version` | Print version |
 
 ## Configuration
@@ -57,6 +119,7 @@ oa status --account 1 --json
 | `OA_AUTH_CLIENT_ID` | Embedded in source | OAuth client identifier |
 | `OA_AUTH_LISTEN` | `127.0.0.1:1455` | Local listener address |
 | `OA_USAGE_BASE_URL` | `https://chatgpt.com/backend-api` | Usage API base URL |
+| `OA_WINDOW_FINGERPRINT` | `default` | Window/session fingerprint for pool continuity |
 
 ## Project layout
 
@@ -71,3 +134,7 @@ oa status --account 1 --json
 ```bash
 go test ./...
 ```
+
+## Roadmap Notes
+
+- See `docs/TODO.md` for planned improvements (including custom pool creation for personal/pro account rotation).

--- a/cmd/cli_test.go
+++ b/cmd/cli_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -429,6 +430,274 @@ func TestUsageCommandFetchesSubscriptionAndRendersRenewal(t *testing.T) {
 	assert.Contains(t, stdout, "14 Mar")
 }
 
+func TestRootAndRunHelpStayConcise(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t, writeAccountsFixture(home))
+
+	rootOut, _, err := executeCLI(t, home, "--help")
+	require.NoError(t, err)
+	assert.Contains(t, rootOut, "oa (OpenAI Accounts CLI) helps you store account auth references")
+	assert.NotContains(t, rootOut, "pool-selected account/session environment")
+
+	runOut, _, err := executeCLI(t, home, "run", "--help")
+	require.NoError(t, err)
+	assert.Contains(t, runOut, "Run a command with pool-selected account env")
+	assert.NotContains(t, runOut, "OA_LOGICAL_SESSION_ID")
+}
+
+func TestPoolActivateCreatesDefaultPool(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t, writeAccountsFixture(home))
+
+	stdout, _, err := executeCLI(t, home, "pool", "activate")
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "Activated pool default-openai")
+	assert.Contains(t, stdout, "members: 1")
+}
+
+func TestPoolStatusReportsPoolState(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t, writeAccountsFixtureWithTwoNamedAccounts(home))
+
+	_, _, err := executeCLI(t, home, "pool", "activate")
+	require.NoError(t, err)
+
+	stdout, _, err := executeCLI(t, home, "pool", "status")
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "pool: default-openai")
+	assert.Contains(t, stdout, "active: true")
+	assert.Contains(t, stdout, "members: user1@example.com")
+	assert.Contains(t, stdout, "members: user1@example.com, user+alt@example.com")
+}
+
+func TestPoolDeactivateDisablesDefaultPool(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t, writeAccountsFixture(home))
+
+	_, _, err := executeCLI(t, home, "pool", "activate")
+	require.NoError(t, err)
+
+	stdout, _, err := executeCLI(t, home, "pool", "deactivate")
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "Deactivated pool default-openai")
+
+	statusOut, _, err := executeCLI(t, home, "pool", "status")
+	require.NoError(t, err)
+	assert.Contains(t, statusOut, "active: false")
+}
+
+func TestRunFailsWhenPoolIsDeactivated(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t, writeAccountsFixture(home))
+
+	_, _, err := executeCLI(t, home, "pool", "activate")
+	require.NoError(t, err)
+
+	_, _, err = executeCLI(t, home, "pool", "deactivate")
+	require.NoError(t, err)
+
+	_, _, err = executeCLI(t, home, "run", "--pool", "default-openai", "--", "sh", "-c", "echo ok")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pool is deactivated")
+}
+
+func TestPoolStatusSanitizesControlCharactersInMemberNames(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t, writeAccountsFixtureWithControlChars(home))
+
+	_, _, err := executeCLI(t, home, "pool", "activate")
+	require.NoError(t, err)
+
+	stdout, _, err := executeCLI(t, home, "pool", "status")
+	require.NoError(t, err)
+	assert.NotContains(t, stdout, "\x1b")
+	assert.NotContains(t, stdout, "\a")
+	assert.Contains(t, stdout, "members: user1@example.comred")
+}
+
+func TestPoolSwitchInteractiveSelectsNumberedAccount(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t, writeAccountsFixtureWithTwoNamedAccounts(home))
+
+	_, _, err := executeCLI(t, home, "pool", "activate")
+	require.NoError(t, err)
+
+	stdout, _, err := executeCLIWithInput(t, home, "2\n", "pool", "switch")
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "1) user1@example.com")
+	assert.Contains(t, stdout, "2) user+alt@example.com")
+	assert.Contains(t, stdout, "Switched to account 2")
+}
+
+func TestPoolNextRotatesFromCurrentAccount(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t, writeAccountsFixtureWithTwoNamedAccounts(home))
+
+	_, _, err := executeCLI(t, home, "pool", "activate")
+	require.NoError(t, err)
+
+	_, _, err = executeCLI(t, home, "pool", "switch", "--account", "1")
+	require.NoError(t, err)
+
+	stdout, _, err := executeCLI(t, home, "pool", "next")
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "Switched to account 2")
+}
+
+func TestPoolSwitchSyncsOpencodeAuthImmediately(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t, writeAccountsFixtureWithTwoChatGPTAuth(home))
+	require.NoError(t, writeOAuthSecretFixture(home, "1", "user1@example.com", "acct-1"))
+	require.NoError(t, writeOAuthSecretFixture(home, "2", "user2@example.com", "acct-2"))
+
+	_, _, err := executeCLI(t, home, "pool", "activate")
+	require.NoError(t, err)
+
+	_, _, err = executeCLI(t, home, "pool", "switch", "--account", "2")
+	require.NoError(t, err)
+
+	auth := readOpencodeAuthFixture(t, home)
+	openai := auth["openai"].(map[string]any)
+	assert.Equal(t, "oauth", openai["type"])
+	assert.Equal(t, "acct-2", openai["accountId"])
+}
+
+func TestPoolNextSyncsOpencodeAuthImmediately(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t, writeAccountsFixtureWithTwoChatGPTAuth(home))
+	require.NoError(t, writeOAuthSecretFixture(home, "1", "user1@example.com", "acct-1"))
+	require.NoError(t, writeOAuthSecretFixture(home, "2", "user2@example.com", "acct-2"))
+
+	_, _, err := executeCLI(t, home, "pool", "activate")
+	require.NoError(t, err)
+	_, _, err = executeCLI(t, home, "pool", "switch", "--account", "1")
+	require.NoError(t, err)
+
+	_, _, err = executeCLI(t, home, "pool", "next")
+	require.NoError(t, err)
+
+	auth := readOpencodeAuthFixture(t, home)
+	openai := auth["openai"].(map[string]any)
+	assert.Equal(t, "acct-2", openai["accountId"])
+}
+
+func TestRunUsesSwitchedAccountWhenSet(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t, writeAccountsFixtureWithTwoNamedAccounts(home))
+
+	_, _, err := executeCLI(t, home, "pool", "activate")
+	require.NoError(t, err)
+
+	_, _, err = executeCLI(t, home, "pool", "switch", "--account", "2")
+	require.NoError(t, err)
+
+	stdout, _, err := executeCLI(t, home, "run", "--pool", "default-openai", "--", "sh", "-c", "printf '%s' \"$OA_ACTIVE_ACCOUNT\"")
+	require.NoError(t, err)
+	assert.Equal(t, "2", strings.TrimSpace(stdout))
+}
+
+func TestRunOpencodeSyncsAuthButOtherCommandsDoNot(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t, writeAccountsFixtureWithTwoChatGPTAuth(home))
+	require.NoError(t, writeOAuthSecretFixture(home, "1", "user1@example.com", "acct-1"))
+	require.NoError(t, writeOAuthSecretFixture(home, "2", "user2@example.com", "acct-2"))
+
+	binsDir := filepath.Join(home, "bin")
+	require.NoError(t, os.MkdirAll(binsDir, 0o755))
+	opencodePath := filepath.Join(binsDir, "opencode")
+	require.NoError(t, os.WriteFile(opencodePath, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	t.Setenv("PATH", binsDir+":"+os.Getenv("PATH"))
+
+	_, _, err := executeCLI(t, home, "pool", "activate")
+	require.NoError(t, err)
+	_, _, err = executeCLI(t, home, "pool", "switch", "--account", "2")
+	require.NoError(t, err)
+
+	_, _, err = executeCLI(t, home, "run", "--", "opencode")
+	require.NoError(t, err)
+	auth := readOpencodeAuthFixture(t, home)
+	assert.Equal(t, "acct-2", auth["openai"].(map[string]any)["accountId"])
+
+	require.NoError(t, os.Remove(filepath.Join(home, ".local", "share", "opencode", "auth.json")))
+	_, _, err = executeCLI(t, home, "run", "--", "sh", "-c", "exit 0")
+	require.NoError(t, err)
+	_, statErr := os.Stat(filepath.Join(home, ".local", "share", "opencode", "auth.json"))
+	assert.ErrorIs(t, statErr, os.ErrNotExist)
+}
+
+func TestPoolSwitchPreservesRuntimeMemoryLedger(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t, writeAccountsFixtureWithTwoChatGPTAuth(home))
+	require.NoError(t, writeOAuthSecretFixture(home, "1", "user1@example.com", "acct-1"))
+	require.NoError(t, writeOAuthSecretFixture(home, "2", "user2@example.com", "acct-2"))
+	require.NoError(t, writePoolRuntimeFixture(home, "existing-memory"))
+
+	_, _, err := executeCLI(t, home, "pool", "activate")
+	require.NoError(t, err)
+	_, _, err = executeCLI(t, home, "pool", "switch", "--account", "2")
+	require.NoError(t, err)
+
+	runtimePath := filepath.Join(home, ".codex", "pool_runtime.toml")
+	data, err := os.ReadFile(runtimePath)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "existing-memory")
+}
+
+func TestStatusMarksActiveAccountInTitle(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t, writeAccountsFixtureWithTwoNamedAccounts(home))
+
+	_, _, err := executeCLI(t, home, "pool", "activate")
+	require.NoError(t, err)
+
+	_, _, err = executeCLI(t, home, "pool", "switch", "--account", "2")
+	require.NoError(t, err)
+
+	stdout, _, err := executeCLI(t, home, "status")
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "Account: user+alt@example.com (Unknown, Active)")
+	assert.Contains(t, stdout, "Account: user1@example.com (Unknown)")
+}
+
+func TestRunUsesSelectedPoolAccountInChildEnv(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t, writeAccountsFixture(home))
+
+	_, _, err := executeCLI(t, home, "pool", "activate")
+	require.NoError(t, err)
+
+	stdout, _, err := executeCLI(t, home, "run", "--pool", "default-openai", "--", "sh", "-c", "printf '%s:%s' \"$OA_POOL_ID\" \"$OA_ACTIVE_ACCOUNT\"")
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "default-openai:acc-1")
+}
+
+func TestRunRequiresCommandAfterDoubleDash(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t, writeAccountsFixture(home))
+
+	_, _, err := executeCLI(t, home, "run", "--pool", "default-openai")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires a command after '--'")
+}
+
+func TestRunKeepsLogicalSessionStableForSameWorkspaceAndWindow(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t, writeAccountsFixture(home))
+
+	_, _, err := executeCLI(t, home, "pool", "activate")
+	require.NoError(t, err)
+
+	t.Setenv("OA_WINDOW_FINGERPRINT", "window-a")
+	one, _, err := executeCLI(t, home, "run", "--pool", "default-openai", "--", "sh", "-c", "printf '%s|%s' \"$OA_LOGICAL_SESSION_ID\" \"$OA_PROVIDER_SESSION_ID\"")
+	require.NoError(t, err)
+	two, _, err := executeCLI(t, home, "run", "--pool", "default-openai", "--", "sh", "-c", "printf '%s|%s' \"$OA_LOGICAL_SESSION_ID\" \"$OA_PROVIDER_SESSION_ID\"")
+	require.NoError(t, err)
+
+	assert.Equal(t, one, two)
+	assert.Contains(t, one, "|")
+	assert.NotEqual(t, "|", one)
+}
+
 func executeCLI(t *testing.T, home string, args ...string) (string, string, error) {
 	t.Helper()
 	t.Setenv("HOME", home)
@@ -436,8 +705,27 @@ func executeCLI(t *testing.T, home string, args ...string) (string, string, erro
 	root := newRootCmd()
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
+	stdin := bytes.NewBufferString("")
 	root.SetOut(stdout)
 	root.SetErr(stderr)
+	root.SetIn(stdin)
+	root.SetArgs(args)
+
+	err := root.Execute()
+	return stdout.String(), stderr.String(), err
+}
+
+func executeCLIWithInput(t *testing.T, home string, input string, args ...string) (string, string, error) {
+	t.Helper()
+	t.Setenv("HOME", home)
+
+	root := newRootCmd()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	stdin := bytes.NewBufferString(input)
+	root.SetOut(stdout)
+	root.SetErr(stderr)
+	root.SetIn(stdin)
 	root.SetArgs(args)
 
 	err := root.Execute()
@@ -489,6 +777,148 @@ secret_ref = "openai://acc-1/oauth_tokens"
 method = "chatgpt"
 secret_ref = "openai://acc-1/oauth_tokens"
 `
+
+	return os.WriteFile(filepath.Join(configDir, "accounts.toml"), []byte(accounts), 0o644)
+}
+
+func writeAccountsFixtureWithTwoNamedAccounts(home string) error {
+	configDir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		return err
+	}
+
+	accounts := `version = 1
+
+[[accounts]]
+id = "1"
+name = "user1@example.com"
+
+[accounts.metadata]
+provider = "openai"
+model = "gpt-5"
+
+[accounts.auth]
+method = ""
+secret_ref = ""
+
+[[accounts]]
+id = "2"
+name = "user+alt@example.com"
+
+[accounts.metadata]
+provider = "openai"
+model = "gpt-5"
+
+[accounts.auth]
+method = ""
+secret_ref = ""
+`
+
+	return os.WriteFile(filepath.Join(configDir, "accounts.toml"), []byte(accounts), 0o644)
+}
+
+func writeAccountsFixtureWithTwoChatGPTAuth(home string) error {
+	configDir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		return err
+	}
+
+	accounts := `version = 1
+
+[[accounts]]
+id = "1"
+name = "user1@example.com"
+
+[accounts.metadata]
+provider = ""
+model = "gpt-5"
+
+[accounts.auth]
+method = "chatgpt"
+secret_ref = "openai://1/oauth_tokens"
+
+[[accounts]]
+id = "2"
+name = "user2@example.com"
+
+[accounts.metadata]
+provider = ""
+model = "gpt-5"
+
+[accounts.auth]
+method = "chatgpt"
+secret_ref = "openai://2/oauth_tokens"
+`
+
+	return os.WriteFile(filepath.Join(configDir, "accounts.toml"), []byte(accounts), 0o644)
+}
+
+func writeOAuthSecretFixture(home, accountID, email, chatgptAccountID string) error {
+	secretRoot := filepath.Join(home, ".codex", "secrets")
+	key := filepath.Clean("openai://" + accountID + "/oauth_tokens")
+	secretPath := filepath.Join(secretRoot, key)
+	if err := os.MkdirAll(filepath.Dir(secretPath), 0o755); err != nil {
+		return err
+	}
+
+	idPayload := fmt.Sprintf(`{"https://api.openai.com/profile":{"email":%q},"https://api.openai.com/auth":{"chatgpt_account_id":%q}}`, email, chatgptAccountID)
+	tokens := fmt.Sprintf(`{"access_token":%q,"refresh_token":%q,"id_token":%q,"expires_at":1772916150}`,
+		"access-"+accountID,
+		"refresh-"+accountID,
+		fakeJWT(idPayload),
+	)
+
+	return os.WriteFile(secretPath, []byte(tokens), 0o600)
+}
+
+func readOpencodeAuthFixture(t *testing.T, home string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(home, ".local", "share", "opencode", "auth.json"))
+	require.NoError(t, err)
+
+	var auth map[string]any
+	require.NoError(t, json.Unmarshal(data, &auth))
+	return auth
+}
+
+func writePoolRuntimeFixture(home, memorySummary string) error {
+	path := filepath.Join(home, ".codex", "pool_runtime.toml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+
+	runtime := fmt.Sprintf(`version = 1
+
+[[runtimes]]
+pool_id = 'default-openai'
+active_account_id = '1'
+last_synced_at = '2026-02-28T17:54:13+01:00'
+
+[[runtimes.sessions]]
+logical_session_id = 'abc123'
+
+[[runtimes.sessions.account_sessions]]
+account_id = '1'
+session_id = 'sess-1'
+
+[runtimes.sessions.memory]
+summary = %q
+decisions = []
+pending_tasks = []
+last_code_refs = []
+updated_at = ''
+`, memorySummary)
+
+	return os.WriteFile(path, []byte(runtime), 0o644)
+}
+
+func writeAccountsFixtureWithControlChars(home string) error {
+	configDir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		return err
+	}
+
+	accounts := "version = 1\n\n[[accounts]]\nid = \"1\"\nname = \"user1@example.com\\u001bred\\u0007\"\n\n[accounts.metadata]\nprovider = \"openai\"\nmodel = \"gpt-5\"\n\n[accounts.auth]\nmethod = \"\"\nsecret_ref = \"\"\n"
 
 	return os.WriteFile(filepath.Join(configDir, "accounts.toml"), []byte(accounts), 0o644)
 }

--- a/cmd/opencode_auth_sync.go
+++ b/cmd/opencode_auth_sync.go
@@ -1,0 +1,158 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/bnema/openai-accounts-cli/internal/domain"
+)
+
+type opencodeOAuthAuth struct {
+	Type      string `json:"type"`
+	Refresh   string `json:"refresh"`
+	Access    string `json:"access"`
+	ExpiresMS int64  `json:"expires,omitempty"`
+	AccountID string `json:"accountId,omitempty"`
+}
+
+func syncOpencodeAuthForAccount(ctx context.Context, app *app, accountID domain.AccountID) error {
+	status, err := app.service.GetStatus(ctx, accountID)
+	if err != nil {
+		return fmt.Errorf("load account for opencode auth sync: %w", err)
+	}
+
+	if status.Account.Auth.Method != domain.AuthMethodChatGPT {
+		return nil
+	}
+
+	secretRef := strings.TrimSpace(status.Account.Auth.SecretRef)
+	if secretRef == "" {
+		return nil
+	}
+
+	secretValue, err := app.secretStore.Get(ctx, secretRef)
+	if err != nil {
+		return fmt.Errorf("load oauth secret for opencode auth sync: %w", err)
+	}
+
+	tokens, err := decodeOAuthTokens(secretValue)
+	if err != nil {
+		return fmt.Errorf("decode oauth secret for opencode auth sync: %w", err)
+	}
+
+	entry := opencodeOAuthAuth{
+		Type:      "oauth",
+		Refresh:   tokens.RefreshToken,
+		Access:    tokens.AccessToken,
+		ExpiresMS: tokenExpiryMillis(tokens, app.now),
+		AccountID: accountIDFromToken(tokens.IDToken),
+	}
+
+	path, err := opencodeAuthPath()
+	if err != nil {
+		return err
+	}
+
+	content, err := readOpencodeAuthMap(path)
+	if err != nil {
+		return err
+	}
+	content["openai"] = entry
+
+	return writeOpencodeAuthMap(path, content)
+}
+
+func shouldSyncOpencodeAuth(command string) bool {
+	return filepath.Base(strings.TrimSpace(command)) == "opencode"
+}
+
+func opencodeAuthPath() (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home directory for opencode auth sync: %w", err)
+	}
+
+	return filepath.Join(homeDir, ".local", "share", "opencode", "auth.json"), nil
+}
+
+func readOpencodeAuthMap(path string) (map[string]any, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]any{}, nil
+		}
+		return nil, fmt.Errorf("read opencode auth file: %w", err)
+	}
+
+	var content map[string]any
+	if err := json.Unmarshal(data, &content); err != nil {
+		return nil, fmt.Errorf("decode opencode auth file: %w", err)
+	}
+
+	if content == nil {
+		content = map[string]any{}
+	}
+
+	return content, nil
+}
+
+func writeOpencodeAuthMap(path string, content map[string]any) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("create opencode auth directory: %w", err)
+	}
+
+	data, err := json.MarshalIndent(content, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode opencode auth file: %w", err)
+	}
+
+	tmp, err := os.CreateTemp(filepath.Dir(path), "auth-*.json")
+	if err != nil {
+		return fmt.Errorf("create temp opencode auth file: %w", err)
+	}
+	tmpName := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp opencode auth file: %w", err)
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("chmod temp opencode auth file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp opencode auth file: %w", err)
+	}
+
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("replace opencode auth file: %w", err)
+	}
+	cleanup = false
+
+	if err := os.Chmod(path, 0o600); err != nil {
+		return fmt.Errorf("chmod opencode auth file: %w", err)
+	}
+
+	return nil
+}
+
+func tokenExpiryMillis(tokens oauthTokens, now func() time.Time) int64 {
+	if tokens.ExpiresAt > 0 {
+		return tokens.ExpiresAt * 1000
+	}
+	if tokens.ExpiresIn > 0 {
+		return now().Add(time.Duration(tokens.ExpiresIn) * time.Second).UnixMilli()
+	}
+	return 0
+}

--- a/cmd/pool.go
+++ b/cmd/pool.go
@@ -1,0 +1,233 @@
+package cmd
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"github.com/bnema/openai-accounts-cli/internal/application"
+	"github.com/bnema/openai-accounts-cli/internal/domain"
+	"github.com/spf13/cobra"
+)
+
+func newPoolCmd(app *app) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "pool",
+		Short: "Manage pooled provider accounts",
+	}
+
+	cmd.AddCommand(
+		newPoolActivateCmd(app),
+		newPoolDeactivateCmd(app),
+		newPoolStatusCmd(app),
+		newPoolNextCmd(app),
+		newPoolSwitchCmd(app),
+	)
+
+	return cmd
+}
+
+func newPoolActivateCmd(app *app) *cobra.Command {
+	return &cobra.Command{
+		Use:   "activate",
+		Short: "Activate the default OpenAI pool",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			pool, err := app.poolService.ActivateDefaultOpenAIPool(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Activated pool %s (members: %d)\n", pool.ID, len(pool.Members))
+			return nil
+		},
+	}
+}
+
+func newPoolDeactivateCmd(app *app) *cobra.Command {
+	return &cobra.Command{
+		Use:   "deactivate",
+		Short: "Deactivate the default OpenAI pool",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			pool, err := app.poolService.DeactivatePool(cmd.Context(), application.DefaultOpenAIPoolID)
+			if err != nil {
+				return err
+			}
+
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Deactivated pool %s\n", pool.ID)
+			return nil
+		},
+	}
+}
+
+func newPoolStatusCmd(app *app) *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Show default pool status",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			pool, err := app.poolService.GetPool(cmd.Context(), application.DefaultOpenAIPoolID)
+			if err != nil {
+				if err == domain.ErrPoolNotFound {
+					_, _ = fmt.Fprintln(cmd.OutOrStdout(), "pool: default-openai")
+					_, _ = fmt.Fprintln(cmd.OutOrStdout(), "active: false")
+					_, _ = fmt.Fprintln(cmd.OutOrStdout(), "members: none")
+					return nil
+				}
+				return err
+			}
+
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "pool: %s\n", pool.ID)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "active: %t\n", pool.Active)
+			if len(pool.Members) == 0 {
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "members: none")
+				return nil
+			}
+
+			members := make([]string, 0, len(pool.Members))
+			for _, member := range pool.Members {
+				status, statusErr := app.service.GetStatus(cmd.Context(), member)
+				if statusErr == nil && strings.TrimSpace(status.Account.Name) != "" {
+					members = append(members, sanitizeForTerminal(status.Account.Name))
+					continue
+				}
+				members = append(members, sanitizeForTerminal(string(member)))
+			}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "members: %s\n", strings.Join(members, ", "))
+			return nil
+		},
+	}
+}
+
+func newPoolNextCmd(app *app) *cobra.Command {
+	var poolID string
+
+	cmd := &cobra.Command{
+		Use:   "next",
+		Short: "Switch to next eligible account",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			current, err := app.continuityService.GetActiveAccountID(cmd.Context(), domain.PoolID(poolID))
+			if err != nil {
+				return err
+			}
+
+			next, err := app.poolService.NextAccount(cmd.Context(), domain.PoolID(poolID), current)
+			if err != nil {
+				return err
+			}
+
+			if err := app.continuityService.SetActiveAccountID(cmd.Context(), domain.PoolID(poolID), next); err != nil {
+				return err
+			}
+
+			if err := syncOpencodeAuthForAccount(cmd.Context(), app, next); err != nil {
+				return err
+			}
+
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Switched to account %s\n", next)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&poolID, "pool", string(application.DefaultOpenAIPoolID), "Pool ID")
+
+	return cmd
+}
+
+func newPoolSwitchCmd(app *app) *cobra.Command {
+	var poolID string
+	var accountSelector string
+
+	cmd := &cobra.Command{
+		Use:   "switch",
+		Short: "Switch to a specific eligible account",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			eligible, err := app.poolService.EligibleAccounts(cmd.Context(), domain.PoolID(poolID))
+			if err != nil {
+				return err
+			}
+
+			target, err := resolveSwitchTarget(cmd, app, eligible, accountSelector)
+			if err != nil {
+				return err
+			}
+
+			if err := app.continuityService.SetActiveAccountID(cmd.Context(), domain.PoolID(poolID), target.ID); err != nil {
+				return err
+			}
+
+			if err := syncOpencodeAuthForAccount(cmd.Context(), app, target.ID); err != nil {
+				return err
+			}
+
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Switched to account %s\n", target.ID)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&poolID, "pool", string(application.DefaultOpenAIPoolID), "Pool ID")
+	cmd.Flags().StringVar(&accountSelector, "account", "", "Target account ID or name")
+
+	return cmd
+}
+
+func resolveSwitchTarget(cmd *cobra.Command, app *app, eligible []domain.Account, selector string) (domain.Account, error) {
+	trimmed := strings.TrimSpace(selector)
+	if trimmed != "" {
+		for _, account := range eligible {
+			if string(account.ID) == trimmed {
+				return account, nil
+			}
+			name := displayAccountName(app, cmd, account)
+			if strings.EqualFold(name, trimmed) {
+				return account, nil
+			}
+		}
+		return domain.Account{}, fmt.Errorf("account %q is not eligible in pool", selector)
+	}
+
+	for i, account := range eligible {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%d) %s\n", i+1, displayAccountName(app, cmd, account))
+	}
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Select account [1-%d]: ", len(eligible))
+
+	reader := bufio.NewReader(cmd.InOrStdin())
+	input, err := reader.ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return domain.Account{}, fmt.Errorf("read account selection: %w", err)
+	}
+
+	choice, err := strconv.Atoi(strings.TrimSpace(input))
+	if err != nil {
+		return domain.Account{}, fmt.Errorf("invalid selection %q", strings.TrimSpace(input))
+	}
+	if choice < 1 || choice > len(eligible) {
+		return domain.Account{}, fmt.Errorf("selection out of range: %d", choice)
+	}
+
+	return eligible[choice-1], nil
+}
+
+func displayAccountName(app *app, cmd *cobra.Command, account domain.Account) string {
+	status, err := app.service.GetStatus(cmd.Context(), account.ID)
+	if err == nil && strings.TrimSpace(status.Account.Name) != "" {
+		return sanitizeForTerminal(status.Account.Name)
+	}
+
+	if strings.TrimSpace(account.Name) != "" {
+		return sanitizeForTerminal(account.Name)
+	}
+
+	return sanitizeForTerminal(string(account.ID))
+}
+
+func sanitizeForTerminal(value string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, value)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,6 +27,8 @@ func newRootCmd() *cobra.Command {
 		newVersionCmd(),
 		newAccountCmd(app),
 		newAuthCmd(app),
+		newPoolCmd(app),
+		newRunCmd(app),
 		newUsageCmd(app),
 	)
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1,0 +1,95 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/bnema/openai-accounts-cli/internal/application"
+	"github.com/bnema/openai-accounts-cli/internal/domain"
+	"github.com/spf13/cobra"
+)
+
+func newRunCmd(app *app) *cobra.Command {
+	var poolID string
+
+	cmd := &cobra.Command{
+		Use:                "run -- <command> [args...]",
+		Short:              "Run a command with pool-selected account env",
+		DisableFlagParsing: false,
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return fmt.Errorf("run requires a command after '--'")
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var picked domain.AccountID
+
+			active, err := app.continuityService.GetActiveAccountID(cmd.Context(), domain.PoolID(poolID))
+			if err != nil {
+				return err
+			}
+			if active != "" {
+				eligible, err := app.poolService.IsEligibleAccount(cmd.Context(), domain.PoolID(poolID), active)
+				if err != nil {
+					return err
+				}
+				if eligible {
+					picked = active
+				}
+			}
+
+			if picked == "" {
+				picked, _, err = app.poolService.PickAccount(cmd.Context(), domain.PoolID(poolID))
+				if err != nil {
+					return err
+				}
+			}
+
+			if err := app.continuityService.SetActiveAccountID(cmd.Context(), domain.PoolID(poolID), picked); err != nil {
+				return err
+			}
+
+			if shouldSyncOpencodeAuth(args[0]) {
+				if err := syncOpencodeAuthForAccount(cmd.Context(), app, picked); err != nil {
+					return err
+				}
+			}
+
+			workspaceRoot, err := os.Getwd()
+			if err != nil {
+				return fmt.Errorf("resolve workspace root: %w", err)
+			}
+			workspaceRoot = filepath.Clean(workspaceRoot)
+			windowFingerprint := envOrDefault("OA_WINDOW_FINGERPRINT", "default")
+			logicalSessionID := app.continuityService.ResolveLogicalSessionID(workspaceRoot, windowFingerprint)
+			providerSessionID, _, err := app.continuityService.GetOrAttachAccountSession(cmd.Context(), domain.PoolID(poolID), logicalSessionID, picked)
+			if err != nil {
+				return fmt.Errorf("resolve provider session: %w", err)
+			}
+
+			child := exec.CommandContext(cmd.Context(), args[0], args[1:]...)
+			child.Stdout = cmd.OutOrStdout()
+			child.Stderr = cmd.ErrOrStderr()
+			child.Stdin = cmd.InOrStdin()
+			child.Env = append(os.Environ(),
+				"OA_POOL_ID="+poolID,
+				"OA_ACTIVE_ACCOUNT="+string(picked),
+				"OA_LOGICAL_SESSION_ID="+logicalSessionID,
+				"OA_PROVIDER_SESSION_ID="+providerSessionID,
+			)
+
+			if err := child.Run(); err != nil {
+				return fmt.Errorf("run child command: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&poolID, "pool", string(application.DefaultOpenAIPoolID), "Pool ID")
+
+	return cmd
+}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -18,9 +18,15 @@ func writeStatusesOutput(cmd *cobra.Command, app *app, statuses []application.St
 		return enc.Encode(statuses)
 	}
 
+	activeAccountID, err := app.continuityService.GetActiveAccountID(cmd.Context(), application.DefaultOpenAIPoolID)
+	if err != nil {
+		return fmt.Errorf("load active pool account: %w", err)
+	}
+
 	rendered, err := app.statusRenderer(statuses, statusadapter.RenderOptions{
-		Now:        app.now(),
-		StaleAfter: staleAfter,
+		Now:             app.now(),
+		StaleAfter:      staleAfter,
+		ActiveAccountID: activeAccountID,
 	})
 	if err != nil {
 		return fmt.Errorf("render status: %w", err)

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,0 +1,8 @@
+# TODO
+
+## Pooling
+
+- [ ] Add custom pool creation and management commands.
+  - Proposed commands: `oa pool create`, `oa pool add`, `oa pool remove`, `oa pool list`.
+  - Goal: support separate pools for contexts like personal vs pro/team accounts and quick switching between those pools.
+  - Include behavior for selecting the active pool in `oa run` and `oa usage` views.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -77,3 +77,47 @@ go run . login browser --account 1
 ```bash
 go run . login device --account 1
 ```
+
+## Pooling and Auto-Switching
+
+Activate the default OpenAI pool (auto-discovers OpenAI accounts):
+
+```bash
+go run . pool activate
+```
+
+Show pool status:
+
+```bash
+go run . pool status
+```
+
+Switch to the next eligible account in pool order:
+
+```bash
+go run . pool next
+```
+
+Switch to a specific eligible account:
+
+```bash
+go run . pool switch --account 2
+```
+
+Interactive switch (choose from numbered eligible accounts):
+
+```bash
+go run . pool switch
+```
+
+Deactivate the default pool:
+
+```bash
+go run . pool deactivate
+```
+
+Run opencode with pool-selected account and continuity env:
+
+```bash
+go run . run --pool default-openai -- opencode
+```

--- a/docs/pool-session-continuity.md
+++ b/docs/pool-session-continuity.md
@@ -1,0 +1,24 @@
+# Pool Session Continuity
+
+`oa run` provides pool-level continuity metadata so tools can keep context while switching accounts.
+
+## How it works
+
+- `oa pool activate` creates/enables `default-openai` and auto-syncs OpenAI accounts.
+- `oa run --pool default-openai -- <cmd>` picks the best non-exhausted account.
+- `oa` resolves a logical session ID from `workspace_root + OA_WINDOW_FINGERPRINT`.
+- `oa` maps that logical session to an account-scoped provider session ID in `~/.codex/pool_runtime.toml`.
+- When account selection changes, the same logical session is reused and a provider session mapping is attached for the target account.
+
+## Environment variables injected by `oa run`
+
+- `OA_POOL_ID`: selected pool ID.
+- `OA_ACTIVE_ACCOUNT`: selected account ID.
+- `OA_LOGICAL_SESSION_ID`: stable cross-account logical session key.
+- `OA_PROVIDER_SESSION_ID`: account-scoped provider session key.
+
+## Limits
+
+- Provider-native conversation IDs are account-scoped and cannot be shared directly across accounts.
+- Continuity is modeled as logical-session linkage with account-session mapping.
+- `OA_WINDOW_FINGERPRINT` should be unique per active window to avoid context collisions.

--- a/internal/adapters/render/status/view.go
+++ b/internal/adapters/render/status/view.go
@@ -13,8 +13,9 @@ import (
 )
 
 type RenderOptions struct {
-	Now        time.Time
-	StaleAfter time.Duration
+	Now             time.Time
+	StaleAfter      time.Duration
+	ActiveAccountID domain.AccountID
 }
 
 func renderView(statuses []application.Status, opts RenderOptions, s styles) string {
@@ -292,7 +293,7 @@ func renderAccount(status application.Status, opts RenderOptions, s styles) stri
 	}
 
 	parts := []string{
-		titleStyle.Render(accountTitle(status.Account.Name, status.Account.ID, status.Account.Metadata.PlanType)),
+		titleStyle.Render(accountTitle(status.Account.Name, status.Account.ID, status.Account.Metadata.PlanType, status.Account.ID == opts.ActiveAccountID)),
 	}
 
 	for _, line := range limitLines(status, opts, s) {
@@ -463,11 +464,18 @@ func formatResetRelative(resetsAt, now time.Time) string {
 	return fmt.Sprintf("resets in %d %s (%s)", days, suffix, resetsAt.Format("15:04 on 02 Jan"))
 }
 
-func accountTitle(name string, id domain.AccountID, planType string) string {
+func accountTitle(name string, id domain.AccountID, planType string, active bool) string {
 	trimmed := strings.TrimSpace(name)
+	activeSuffix := ""
+	if active {
+		activeSuffix = ", Active"
+	}
 	if strings.Contains(trimmed, "@") {
 		classification := domain.AccountClassification(planType)
-		return fmt.Sprintf("Account: %s (%s)", trimmed, classification)
+		return fmt.Sprintf("Account: %s (%s%s)", trimmed, classification, activeSuffix)
+	}
+	if active {
+		return fmt.Sprintf("%s (%s, Active)", trimmed, id)
 	}
 	return fmt.Sprintf("%s (%s)", trimmed, id)
 }

--- a/internal/adapters/repo/toml/pool_repository.go
+++ b/internal/adapters/repo/toml/pool_repository.go
@@ -1,0 +1,393 @@
+package toml
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/bnema/openai-accounts-cli/internal/domain"
+	"github.com/bnema/openai-accounts-cli/internal/ports"
+	toml "github.com/pelletier/go-toml/v2"
+	"github.com/spf13/viper"
+)
+
+const (
+	poolsPathKey    = "pools.path"
+	poolConfigFile  = "pools.toml"
+	poolRuntimePath = "pool.runtime.path"
+	runtimeFileName = "pool_runtime.toml"
+)
+
+type PoolRepository struct {
+	path string
+	mu   *sync.RWMutex
+}
+
+var _ ports.PoolRepository = (*PoolRepository)(nil)
+
+func NewPoolRepository(cfg *viper.Viper) (*PoolRepository, error) {
+	if cfg == nil {
+		cfg = viper.New()
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolve home directory: %w", err)
+	}
+
+	path := cfg.GetString(poolsPathKey)
+	if path == "" {
+		path = filepath.Join(homeDir, accountsConfigDir, poolConfigFile)
+	}
+
+	path, err = normalizeAccountsPath(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return &PoolRepository{path: path, mu: lockForPath(path)}, nil
+}
+
+func (r *PoolRepository) Save(ctx context.Context, pool domain.Pool) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	file, err := r.readSchema()
+	if err != nil {
+		return err
+	}
+	file.applyDefaults()
+
+	encoded := toPoolSchema(pool)
+	updated := false
+	for i := range file.Pools {
+		if file.Pools[i].ID == encoded.ID {
+			file.Pools[i] = encoded
+			updated = true
+			break
+		}
+	}
+	if !updated {
+		file.Pools = append(file.Pools, encoded)
+	}
+
+	return writeTOMLFile(r.path, file)
+}
+
+func (r *PoolRepository) GetByID(ctx context.Context, id domain.PoolID) (domain.Pool, error) {
+	if err := ctx.Err(); err != nil {
+		return domain.Pool{}, err
+	}
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	file, err := r.readSchema()
+	if err != nil {
+		return domain.Pool{}, err
+	}
+
+	for _, entry := range file.Pools {
+		if entry.ID == string(id) {
+			return fromPoolSchema(entry), nil
+		}
+	}
+
+	return domain.Pool{}, domain.ErrPoolNotFound
+}
+
+func (r *PoolRepository) List(ctx context.Context) ([]domain.Pool, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	file, err := r.readSchema()
+	if err != nil {
+		return nil, err
+	}
+
+	pools := make([]domain.Pool, 0, len(file.Pools))
+	for _, entry := range file.Pools {
+		pools = append(pools, fromPoolSchema(entry))
+	}
+
+	return pools, nil
+}
+
+func (r *PoolRepository) readSchema() (poolsFileSchema, error) {
+	data, err := os.ReadFile(r.path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return poolsFileSchema{}, nil
+		}
+		return poolsFileSchema{}, fmt.Errorf("read pools file: %w", err)
+	}
+
+	var file poolsFileSchema
+	if err := toml.Unmarshal(data, &file); err != nil {
+		return poolsFileSchema{}, fmt.Errorf("decode pools file: %w", err)
+	}
+	if err := file.validateVersion(); err != nil {
+		return poolsFileSchema{}, err
+	}
+	file.applyDefaults()
+
+	return file, nil
+}
+
+type PoolRuntimeRepository struct {
+	path string
+	mu   *sync.RWMutex
+}
+
+var _ ports.PoolRuntimeRepository = (*PoolRuntimeRepository)(nil)
+
+func NewPoolRuntimeRepository(cfg *viper.Viper) (*PoolRuntimeRepository, error) {
+	if cfg == nil {
+		cfg = viper.New()
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolve home directory: %w", err)
+	}
+
+	path := cfg.GetString(poolRuntimePath)
+	if path == "" {
+		path = filepath.Join(homeDir, accountsConfigDir, runtimeFileName)
+	}
+
+	path, err = normalizeAccountsPath(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return &PoolRuntimeRepository{path: path, mu: lockForPath(path)}, nil
+}
+
+func (r *PoolRuntimeRepository) GetByPoolID(ctx context.Context, poolID domain.PoolID) (domain.PoolRuntime, error) {
+	if err := ctx.Err(); err != nil {
+		return domain.PoolRuntime{}, err
+	}
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	file, err := r.readSchema()
+	if err != nil {
+		return domain.PoolRuntime{}, err
+	}
+
+	for _, runtime := range file.Runtimes {
+		if runtime.PoolID == string(poolID) {
+			return fromPoolRuntimeSchema(runtime), nil
+		}
+	}
+
+	return domain.PoolRuntime{}, domain.ErrPoolNotFound
+}
+
+func (r *PoolRuntimeRepository) Save(ctx context.Context, runtime domain.PoolRuntime) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	file, err := r.readSchema()
+	if err != nil {
+		return err
+	}
+	file.applyDefaults()
+
+	encoded := toPoolRuntimeSchema(runtime)
+	updated := false
+	for i := range file.Runtimes {
+		if file.Runtimes[i].PoolID == encoded.PoolID {
+			file.Runtimes[i] = encoded
+			updated = true
+			break
+		}
+	}
+	if !updated {
+		file.Runtimes = append(file.Runtimes, encoded)
+	}
+
+	return writeTOMLFile(r.path, file)
+}
+
+func (r *PoolRuntimeRepository) readSchema() (poolRuntimeFileSchema, error) {
+	data, err := os.ReadFile(r.path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return poolRuntimeFileSchema{}, nil
+		}
+		return poolRuntimeFileSchema{}, fmt.Errorf("read pool runtime file: %w", err)
+	}
+
+	var file poolRuntimeFileSchema
+	if err := toml.Unmarshal(data, &file); err != nil {
+		return poolRuntimeFileSchema{}, fmt.Errorf("decode pool runtime file: %w", err)
+	}
+	if err := file.validateVersion(); err != nil {
+		return poolRuntimeFileSchema{}, err
+	}
+	file.applyDefaults()
+
+	return file, nil
+}
+
+func writeTOMLFile(path string, file any) error {
+	if err := os.MkdirAll(filepath.Dir(path), accountsDirMode); err != nil {
+		return fmt.Errorf("create directory: %w", err)
+	}
+
+	data, err := toml.Marshal(file)
+	if err != nil {
+		return fmt.Errorf("encode file: %w", err)
+	}
+
+	tempFile, err := os.CreateTemp(filepath.Dir(path), tempFilePattern)
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+
+	tempName := tempFile.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tempName)
+		}
+	}()
+
+	if _, err := tempFile.Write(data); err != nil {
+		_ = tempFile.Close()
+		return fmt.Errorf("write temp file: %w", err)
+	}
+
+	if err := tempFile.Chmod(accountsFileMode); err != nil {
+		_ = tempFile.Close()
+		return fmt.Errorf("chmod temp file: %w", err)
+	}
+
+	if err := tempFile.Close(); err != nil {
+		return fmt.Errorf("close temp file: %w", err)
+	}
+
+	if err := os.Rename(tempName, path); err != nil {
+		return fmt.Errorf("replace file: %w", err)
+	}
+
+	cleanup = false
+
+	if err := os.Chmod(path, accountsFileMode); err != nil {
+		return fmt.Errorf("chmod file: %w", err)
+	}
+
+	return nil
+}
+
+func toPoolSchema(pool domain.Pool) poolSchema {
+	members := make([]string, 0, len(pool.Members))
+	for _, member := range pool.Members {
+		members = append(members, string(member))
+	}
+
+	return poolSchema{
+		ID:              string(pool.ID),
+		Name:            pool.Name,
+		Provider:        string(pool.Provider),
+		Strategy:        string(pool.Strategy),
+		Active:          pool.Active,
+		AutoSyncMembers: pool.AutoSyncMembers,
+		Members:         members,
+		UpdatedAt:       formatTime(pool.UpdatedAt),
+	}
+}
+
+func fromPoolSchema(schema poolSchema) domain.Pool {
+	members := make([]domain.AccountID, 0, len(schema.Members))
+	for _, member := range schema.Members {
+		members = append(members, domain.AccountID(member))
+	}
+
+	return domain.Pool{
+		ID:              domain.PoolID(schema.ID),
+		Name:            schema.Name,
+		Provider:        domain.Provider(schema.Provider),
+		Strategy:        domain.PoolStrategy(schema.Strategy),
+		Active:          schema.Active,
+		AutoSyncMembers: schema.AutoSyncMembers,
+		Members:         members,
+		UpdatedAt:       parseTime(schema.UpdatedAt),
+	}
+}
+
+func toPoolRuntimeSchema(runtime domain.PoolRuntime) poolRuntimeSchema {
+	sessions := make([]sessionLedgerSchema, 0, len(runtime.Sessions))
+	for _, session := range runtime.Sessions {
+		pairs := make([]accountSessionPair, 0, len(session.AccountSessions))
+		for accountID, sessionID := range session.AccountSessions {
+			pairs = append(pairs, accountSessionPair{AccountID: string(accountID), SessionID: sessionID})
+		}
+
+		sessions = append(sessions, sessionLedgerSchema{
+			LogicalSessionID: session.LogicalSessionID,
+			AccountSessions:  pairs,
+			Memory: memoryPacketSchema{
+				Summary:      session.Memory.Summary,
+				Decisions:    session.Memory.Decisions,
+				PendingTasks: session.Memory.PendingTasks,
+				LastCodeRefs: session.Memory.LastCodeRefs,
+				UpdatedAt:    formatTime(session.Memory.UpdatedAt),
+			},
+		})
+	}
+
+	return poolRuntimeSchema{
+		PoolID:          string(runtime.PoolID),
+		ActiveAccountID: string(runtime.ActiveAccountID),
+		LastSyncedAt:    formatTime(runtime.LastSyncedAt),
+		Sessions:        sessions,
+	}
+}
+
+func fromPoolRuntimeSchema(schema poolRuntimeSchema) domain.PoolRuntime {
+	sessions := make(map[string]domain.SessionLedger, len(schema.Sessions))
+	for _, session := range schema.Sessions {
+		accountSessions := make(map[domain.AccountID]string, len(session.AccountSessions))
+		for _, pair := range session.AccountSessions {
+			accountSessions[domain.AccountID(pair.AccountID)] = pair.SessionID
+		}
+
+		sessions[session.LogicalSessionID] = domain.SessionLedger{
+			LogicalSessionID: session.LogicalSessionID,
+			AccountSessions:  accountSessions,
+			Memory: domain.MemoryPacket{
+				Summary:      session.Memory.Summary,
+				Decisions:    session.Memory.Decisions,
+				PendingTasks: session.Memory.PendingTasks,
+				LastCodeRefs: session.Memory.LastCodeRefs,
+				UpdatedAt:    parseTime(session.Memory.UpdatedAt),
+			},
+		}
+	}
+
+	return domain.PoolRuntime{
+		PoolID:          domain.PoolID(schema.PoolID),
+		ActiveAccountID: domain.AccountID(schema.ActiveAccountID),
+		LastSyncedAt:    parseTime(schema.LastSyncedAt),
+		Sessions:        sessions,
+	}
+}

--- a/internal/adapters/repo/toml/pool_repository_test.go
+++ b/internal/adapters/repo/toml/pool_repository_test.go
@@ -1,0 +1,84 @@
+package toml
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/bnema/openai-accounts-cli/internal/domain"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPoolRepositoryRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "pools.toml")
+	cfg := viper.New()
+	cfg.Set("pools.path", path)
+
+	repo, err := NewPoolRepository(cfg)
+	require.NoError(t, err)
+
+	pool := domain.Pool{
+		ID:              "default-openai",
+		Name:            "default",
+		Provider:        domain.ProviderOpenAI,
+		Strategy:        domain.PoolStrategyLeastWeeklyUsed,
+		Active:          true,
+		AutoSyncMembers: true,
+		Members:         []domain.AccountID{"1", "2"},
+		UpdatedAt:       time.Date(2026, 2, 28, 10, 0, 0, 0, time.UTC),
+	}
+
+	require.NoError(t, repo.Save(context.Background(), pool))
+
+	got, err := repo.GetByID(context.Background(), pool.ID)
+	require.NoError(t, err)
+	assert.Equal(t, pool, got)
+
+	all, err := repo.List(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []domain.Pool{pool}, all)
+}
+
+func TestPoolRuntimeRepositoryRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "pool_runtime.toml")
+	cfg := viper.New()
+	cfg.Set("pool.runtime.path", path)
+
+	repo, err := NewPoolRuntimeRepository(cfg)
+	require.NoError(t, err)
+
+	runtime := domain.PoolRuntime{
+		PoolID:          "default-openai",
+		ActiveAccountID: "2",
+		LastSyncedAt:    time.Date(2026, 2, 28, 10, 30, 0, 0, time.UTC),
+		Sessions: map[string]domain.SessionLedger{
+			"workspace-a": {
+				LogicalSessionID: "workspace-a",
+				AccountSessions: map[domain.AccountID]string{
+					"1": "sess-1",
+					"2": "sess-2",
+				},
+				Memory: domain.MemoryPacket{
+					Summary:      "foo",
+					Decisions:    []string{},
+					PendingTasks: []string{},
+					LastCodeRefs: []string{},
+					UpdatedAt:    time.Date(2026, 2, 28, 10, 35, 0, 0, time.UTC),
+				},
+			},
+		},
+	}
+
+	require.NoError(t, repo.Save(context.Background(), runtime))
+
+	got, err := repo.GetByPoolID(context.Background(), runtime.PoolID)
+	require.NoError(t, err)
+	assert.Equal(t, runtime, got)
+}

--- a/internal/adapters/repo/toml/pools_schema.go
+++ b/internal/adapters/repo/toml/pools_schema.go
@@ -1,0 +1,81 @@
+package toml
+
+import "fmt"
+
+const currentPoolsSchemaVersion = 1
+const currentPoolRuntimeSchemaVersion = 1
+
+type poolsFileSchema struct {
+	Version int          `toml:"version"`
+	Pools   []poolSchema `toml:"pools"`
+}
+
+func (s *poolsFileSchema) applyDefaults() {
+	if s.Version == 0 {
+		s.Version = currentPoolsSchemaVersion
+	}
+}
+
+func (s poolsFileSchema) validateVersion() error {
+	if s.Version > currentPoolsSchemaVersion {
+		return fmt.Errorf("unsupported pools schema version %d (current %d)", s.Version, currentPoolsSchemaVersion)
+	}
+
+	return nil
+}
+
+type poolSchema struct {
+	ID              string   `toml:"id"`
+	Name            string   `toml:"name"`
+	Provider        string   `toml:"provider"`
+	Strategy        string   `toml:"strategy"`
+	Active          bool     `toml:"active"`
+	AutoSyncMembers bool     `toml:"auto_sync_members"`
+	Members         []string `toml:"members"`
+	UpdatedAt       string   `toml:"updated_at"`
+}
+
+type poolRuntimeFileSchema struct {
+	Version  int                 `toml:"version"`
+	Runtimes []poolRuntimeSchema `toml:"runtimes"`
+}
+
+func (s *poolRuntimeFileSchema) applyDefaults() {
+	if s.Version == 0 {
+		s.Version = currentPoolRuntimeSchemaVersion
+	}
+}
+
+func (s poolRuntimeFileSchema) validateVersion() error {
+	if s.Version > currentPoolRuntimeSchemaVersion {
+		return fmt.Errorf("unsupported pool runtime schema version %d (current %d)", s.Version, currentPoolRuntimeSchemaVersion)
+	}
+
+	return nil
+}
+
+type poolRuntimeSchema struct {
+	PoolID          string                `toml:"pool_id"`
+	ActiveAccountID string                `toml:"active_account_id"`
+	LastSyncedAt    string                `toml:"last_synced_at"`
+	Sessions        []sessionLedgerSchema `toml:"sessions"`
+}
+
+type sessionLedgerSchema struct {
+	LogicalSessionID string               `toml:"logical_session_id"`
+	AccountSessions  []accountSessionPair `toml:"account_sessions"`
+	Memory           memoryPacketSchema   `toml:"memory"`
+}
+
+type accountSessionPair struct {
+	AccountID string `toml:"account_id"`
+	SessionID string `toml:"session_id"`
+}
+
+type memoryPacketSchema struct {
+	Summary      string   `toml:"summary"`
+	Decisions    []string `toml:"decisions"`
+	PendingTasks []string `toml:"pending_tasks"`
+	LastCodeRefs []string `toml:"last_code_refs"`
+	UpdatedAt    string   `toml:"updated_at"`
+}

--- a/internal/application/pool_service.go
+++ b/internal/application/pool_service.go
@@ -1,0 +1,259 @@
+package application
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/bnema/openai-accounts-cli/internal/domain"
+	"github.com/bnema/openai-accounts-cli/internal/ports"
+)
+
+const DefaultOpenAIPoolID domain.PoolID = "default-openai"
+
+type PoolService struct {
+	accounts ports.AccountRepository
+	pools    ports.PoolRepository
+	clock    ports.Clock
+}
+
+func NewPoolService(accounts ports.AccountRepository, pools ports.PoolRepository, clock ports.Clock) *PoolService {
+	if clock == nil {
+		clock = ports.SystemClock{}
+	}
+
+	return &PoolService{accounts: accounts, pools: pools, clock: clock}
+}
+
+func (s *PoolService) ActivateDefaultOpenAIPool(ctx context.Context) (domain.Pool, error) {
+	accounts, err := s.accounts.List(ctx)
+	if err != nil {
+		return domain.Pool{}, fmt.Errorf("list accounts: %w", err)
+	}
+
+	members := openAIMembers(accounts)
+
+	pool, err := s.pools.GetByID(ctx, DefaultOpenAIPoolID)
+	if err != nil {
+		if err != domain.ErrPoolNotFound {
+			return domain.Pool{}, fmt.Errorf("load default pool: %w", err)
+		}
+		pool = domain.Pool{
+			ID:              DefaultOpenAIPoolID,
+			Name:            "default",
+			Provider:        domain.ProviderOpenAI,
+			Strategy:        domain.PoolStrategyLeastWeeklyUsed,
+			AutoSyncMembers: true,
+		}
+	}
+
+	if pool.AutoSyncMembers {
+		pool.Members = members
+	}
+	pool.Active = true
+	pool.UpdatedAt = s.clock.Now()
+	pool.NormalizeMembers()
+
+	if err := pool.Validate(); err != nil {
+		return domain.Pool{}, err
+	}
+
+	if err := s.pools.Save(ctx, pool); err != nil {
+		return domain.Pool{}, fmt.Errorf("save pool: %w", err)
+	}
+
+	return pool, nil
+}
+
+func (s *PoolService) DeactivatePool(ctx context.Context, poolID domain.PoolID) (domain.Pool, error) {
+	pool, err := s.pools.GetByID(ctx, poolID)
+	if err != nil {
+		return domain.Pool{}, err
+	}
+
+	pool.Active = false
+	pool.UpdatedAt = s.clock.Now()
+	if err := s.pools.Save(ctx, pool); err != nil {
+		return domain.Pool{}, fmt.Errorf("save pool: %w", err)
+	}
+
+	return pool, nil
+}
+
+func (s *PoolService) PickAccount(ctx context.Context, poolID domain.PoolID) (domain.AccountID, []domain.AccountID, error) {
+	pool, err := s.pools.GetByID(ctx, poolID)
+	if err != nil {
+		return "", nil, err
+	}
+	if !pool.Active {
+		return "", nil, domain.ErrPoolInactive
+	}
+
+	accounts, err := s.accounts.List(ctx)
+	if err != nil {
+		return "", nil, fmt.Errorf("list accounts: %w", err)
+	}
+
+	byID := make(map[domain.AccountID]domain.Account, len(accounts))
+	for _, account := range accounts {
+		byID[account.ID] = account
+	}
+
+	candidates := make([]domain.Account, 0, len(pool.Members))
+	for _, member := range pool.Members {
+		account, ok := byID[member]
+		if !ok {
+			continue
+		}
+		if !isPoolProviderMatch(pool, account) {
+			continue
+		}
+		if account.Limits.Weekly != nil && account.Limits.Weekly.Percent >= 100 {
+			continue
+		}
+		candidates = append(candidates, account)
+	}
+
+	if len(candidates) == 0 {
+		return "", nil, fmt.Errorf("no eligible accounts in pool %s", poolID)
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		left := weeklyPercent(candidates[i])
+		right := weeklyPercent(candidates[j])
+		if left == right {
+			return string(candidates[i].ID) < string(candidates[j].ID)
+		}
+		return left < right
+	})
+
+	picked := candidates[0].ID
+	failover := make([]domain.AccountID, 0, len(candidates)-1)
+	for _, candidate := range candidates[1:] {
+		failover = append(failover, candidate.ID)
+	}
+
+	return picked, failover, nil
+}
+
+func (s *PoolService) GetPool(ctx context.Context, poolID domain.PoolID) (domain.Pool, error) {
+	pool, err := s.pools.GetByID(ctx, poolID)
+	if err != nil {
+		return domain.Pool{}, err
+	}
+
+	if pool.AutoSyncMembers {
+		accounts, err := s.accounts.List(ctx)
+		if err != nil {
+			return domain.Pool{}, fmt.Errorf("list accounts: %w", err)
+		}
+		pool.Members = openAIMembers(accounts)
+		pool.NormalizeMembers()
+	}
+
+	return pool, nil
+}
+
+func (s *PoolService) EligibleAccounts(ctx context.Context, poolID domain.PoolID) ([]domain.Account, error) {
+	pool, err := s.pools.GetByID(ctx, poolID)
+	if err != nil {
+		return nil, err
+	}
+	if !pool.Active {
+		return nil, domain.ErrPoolInactive
+	}
+
+	accounts, err := s.accounts.List(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list accounts: %w", err)
+	}
+
+	byID := make(map[domain.AccountID]domain.Account, len(accounts))
+	for _, account := range accounts {
+		byID[account.ID] = account
+	}
+
+	eligible := make([]domain.Account, 0, len(pool.Members))
+	for _, member := range pool.Members {
+		account, ok := byID[member]
+		if !ok {
+			continue
+		}
+		if !isPoolProviderMatch(pool, account) {
+			continue
+		}
+		if account.Limits.Weekly != nil && account.Limits.Weekly.Percent >= 100 {
+			continue
+		}
+		eligible = append(eligible, account)
+	}
+
+	if len(eligible) == 0 {
+		return nil, fmt.Errorf("no eligible accounts in pool %s", poolID)
+	}
+
+	return eligible, nil
+}
+
+func (s *PoolService) NextAccount(ctx context.Context, poolID domain.PoolID, current domain.AccountID) (domain.AccountID, error) {
+	eligible, err := s.EligibleAccounts(ctx, poolID)
+	if err != nil {
+		return "", err
+	}
+
+	if current == "" {
+		return eligible[0].ID, nil
+	}
+
+	for i, account := range eligible {
+		if account.ID != current {
+			continue
+		}
+		return eligible[(i+1)%len(eligible)].ID, nil
+	}
+
+	return eligible[0].ID, nil
+}
+
+func (s *PoolService) IsEligibleAccount(ctx context.Context, poolID domain.PoolID, accountID domain.AccountID) (bool, error) {
+	eligible, err := s.EligibleAccounts(ctx, poolID)
+	if err != nil {
+		return false, err
+	}
+
+	for _, account := range eligible {
+		if account.ID == accountID {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func openAIMembers(accounts []domain.Account) []domain.AccountID {
+	members := make([]domain.AccountID, 0, len(accounts))
+	for _, account := range accounts {
+		provider := strings.TrimSpace(strings.ToLower(account.Metadata.Provider))
+		if provider == string(domain.ProviderOpenAI) || account.Auth.Method == domain.AuthMethodChatGPT {
+			members = append(members, account.ID)
+		}
+	}
+	return members
+}
+
+func weeklyPercent(account domain.Account) float64 {
+	if account.Limits.Weekly == nil {
+		return 0
+	}
+	return account.Limits.Weekly.Percent
+}
+
+func isPoolProviderMatch(pool domain.Pool, account domain.Account) bool {
+	provider := strings.TrimSpace(strings.ToLower(account.Metadata.Provider))
+	if provider == string(pool.Provider) {
+		return true
+	}
+
+	return pool.Provider == domain.ProviderOpenAI && account.Auth.Method == domain.AuthMethodChatGPT
+}

--- a/internal/application/pool_service_test.go
+++ b/internal/application/pool_service_test.go
@@ -1,0 +1,247 @@
+package application
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/bnema/openai-accounts-cli/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPoolServiceActivateDefaultOpenAIPoolCreatesPool(t *testing.T) {
+	t.Parallel()
+
+	repo := &inMemoryAccountRepo{accounts: []domain.Account{
+		{ID: "1", Metadata: domain.AccountMetadata{Provider: "openai"}},
+		{ID: "2", Metadata: domain.AccountMetadata{Provider: "openai"}},
+		{ID: "x", Metadata: domain.AccountMetadata{Provider: "anthropic"}},
+	}}
+	pools := &inMemoryPoolRepo{}
+	svc := NewPoolService(repo, pools, nil)
+
+	pool, err := svc.ActivateDefaultOpenAIPool(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, domain.PoolID("default-openai"), pool.ID)
+	assert.Equal(t, []domain.AccountID{"1", "2"}, pool.Members)
+	assert.True(t, pool.Active)
+	assert.True(t, pool.AutoSyncMembers)
+}
+
+func TestPoolServiceActivateDefaultPoolSyncsMembers(t *testing.T) {
+	t.Parallel()
+
+	repo := &inMemoryAccountRepo{accounts: []domain.Account{
+		{ID: "1", Metadata: domain.AccountMetadata{Provider: "openai"}},
+		{ID: "2", Metadata: domain.AccountMetadata{Provider: "openai"}},
+	}}
+	pools := &inMemoryPoolRepo{pools: map[domain.PoolID]domain.Pool{
+		"default-openai": {
+			ID:              "default-openai",
+			Name:            "default",
+			Provider:        domain.ProviderOpenAI,
+			Strategy:        domain.PoolStrategyLeastWeeklyUsed,
+			Active:          false,
+			AutoSyncMembers: true,
+			Members:         []domain.AccountID{"1"},
+		},
+	}}
+
+	svc := NewPoolService(repo, pools, fixedClock{now: time.Date(2026, 2, 28, 12, 0, 0, 0, time.UTC)})
+
+	pool, err := svc.ActivateDefaultOpenAIPool(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []domain.AccountID{"1", "2"}, pool.Members)
+	assert.True(t, pool.Active)
+}
+
+func TestPoolServicePickAccountSkipsExhausted(t *testing.T) {
+	t.Parallel()
+
+	repo := &inMemoryAccountRepo{accounts: []domain.Account{
+		{ID: "1", Metadata: domain.AccountMetadata{Provider: "openai"}, Limits: domain.AccountLimitSnapshots{Weekly: &domain.AccountLimitSnapshot{Percent: 100}}},
+		{ID: "2", Metadata: domain.AccountMetadata{Provider: "openai"}, Limits: domain.AccountLimitSnapshots{Weekly: &domain.AccountLimitSnapshot{Percent: 30}}},
+		{ID: "3", Metadata: domain.AccountMetadata{Provider: "openai"}, Limits: domain.AccountLimitSnapshots{Weekly: &domain.AccountLimitSnapshot{Percent: 10}}},
+	}}
+	pools := &inMemoryPoolRepo{pools: map[domain.PoolID]domain.Pool{
+		"default-openai": {
+			ID:       "default-openai",
+			Provider: domain.ProviderOpenAI,
+			Active:   true,
+			Members:  []domain.AccountID{"1", "2", "3"},
+		},
+	}}
+	svc := NewPoolService(repo, pools, nil)
+
+	picked, failover, err := svc.PickAccount(context.Background(), "default-openai")
+	require.NoError(t, err)
+	assert.Equal(t, domain.AccountID("3"), picked)
+	assert.Equal(t, []domain.AccountID{"2"}, failover)
+}
+
+func TestPoolServicePickAccountFailsWhenPoolIsInactive(t *testing.T) {
+	t.Parallel()
+
+	repo := &inMemoryAccountRepo{accounts: []domain.Account{
+		{ID: "1", Metadata: domain.AccountMetadata{Provider: "openai"}},
+	}}
+	pools := &inMemoryPoolRepo{pools: map[domain.PoolID]domain.Pool{
+		"default-openai": {
+			ID:       "default-openai",
+			Provider: domain.ProviderOpenAI,
+			Active:   false,
+			Members:  []domain.AccountID{"1"},
+		},
+	}}
+	svc := NewPoolService(repo, pools, nil)
+
+	_, _, err := svc.PickAccount(context.Background(), "default-openai")
+	require.ErrorIs(t, err, domain.ErrPoolInactive)
+}
+
+func TestPoolServiceEligibleAccountsKeepsPoolOrderAndSkipsExhausted(t *testing.T) {
+	t.Parallel()
+
+	repo := &inMemoryAccountRepo{accounts: []domain.Account{
+		{ID: "1", Metadata: domain.AccountMetadata{Provider: "openai"}, Limits: domain.AccountLimitSnapshots{Weekly: &domain.AccountLimitSnapshot{Percent: 10}}},
+		{ID: "2", Metadata: domain.AccountMetadata{Provider: "openai"}, Limits: domain.AccountLimitSnapshots{Weekly: &domain.AccountLimitSnapshot{Percent: 100}}},
+		{ID: "3", Metadata: domain.AccountMetadata{Provider: "openai"}, Limits: domain.AccountLimitSnapshots{Weekly: &domain.AccountLimitSnapshot{Percent: 60}}},
+	}}
+	pools := &inMemoryPoolRepo{pools: map[domain.PoolID]domain.Pool{
+		"default-openai": {
+			ID:       "default-openai",
+			Provider: domain.ProviderOpenAI,
+			Active:   true,
+			Members:  []domain.AccountID{"3", "2", "1"},
+		},
+	}}
+
+	svc := NewPoolService(repo, pools, nil)
+
+	accounts, err := svc.EligibleAccounts(context.Background(), "default-openai")
+	require.NoError(t, err)
+	require.Len(t, accounts, 2)
+	assert.Equal(t, domain.AccountID("3"), accounts[0].ID)
+	assert.Equal(t, domain.AccountID("1"), accounts[1].ID)
+}
+
+func TestPoolServiceNextAccountRotatesInEligibleOrder(t *testing.T) {
+	t.Parallel()
+
+	repo := &inMemoryAccountRepo{accounts: []domain.Account{
+		{ID: "1", Metadata: domain.AccountMetadata{Provider: "openai"}},
+		{ID: "2", Metadata: domain.AccountMetadata{Provider: "openai"}},
+		{ID: "3", Metadata: domain.AccountMetadata{Provider: "openai"}},
+	}}
+	pools := &inMemoryPoolRepo{pools: map[domain.PoolID]domain.Pool{
+		"default-openai": {
+			ID:       "default-openai",
+			Provider: domain.ProviderOpenAI,
+			Active:   true,
+			Members:  []domain.AccountID{"1", "2", "3"},
+		},
+	}}
+
+	svc := NewPoolService(repo, pools, nil)
+
+	next, err := svc.NextAccount(context.Background(), "default-openai", "1")
+	require.NoError(t, err)
+	assert.Equal(t, domain.AccountID("2"), next)
+
+	wrapped, err := svc.NextAccount(context.Background(), "default-openai", "3")
+	require.NoError(t, err)
+	assert.Equal(t, domain.AccountID("1"), wrapped)
+}
+
+func TestPoolServiceEligibleAccountsIncludesChatGPTAuthWithEmptyProvider(t *testing.T) {
+	t.Parallel()
+
+	repo := &inMemoryAccountRepo{accounts: []domain.Account{
+		{ID: "1", Metadata: domain.AccountMetadata{Provider: ""}, Auth: domain.Auth{Method: domain.AuthMethodChatGPT}},
+		{ID: "2", Metadata: domain.AccountMetadata{Provider: ""}, Auth: domain.Auth{Method: domain.AuthMethodChatGPT}},
+	}}
+	pools := &inMemoryPoolRepo{pools: map[domain.PoolID]domain.Pool{
+		"default-openai": {
+			ID:       "default-openai",
+			Provider: domain.ProviderOpenAI,
+			Active:   true,
+			Members:  []domain.AccountID{"1", "2"},
+		},
+	}}
+
+	svc := NewPoolService(repo, pools, nil)
+
+	eligible, err := svc.EligibleAccounts(context.Background(), "default-openai")
+	require.NoError(t, err)
+	require.Len(t, eligible, 2)
+	assert.Equal(t, domain.AccountID("1"), eligible[0].ID)
+	assert.Equal(t, domain.AccountID("2"), eligible[1].ID)
+}
+
+type inMemoryPoolRepo struct {
+	pools map[domain.PoolID]domain.Pool
+}
+
+func (r *inMemoryPoolRepo) GetByID(_ context.Context, id domain.PoolID) (domain.Pool, error) {
+	if r.pools == nil {
+		r.pools = map[domain.PoolID]domain.Pool{}
+	}
+	pool, ok := r.pools[id]
+	if !ok {
+		return domain.Pool{}, domain.ErrPoolNotFound
+	}
+	return pool, nil
+}
+
+func (r *inMemoryPoolRepo) List(_ context.Context) ([]domain.Pool, error) {
+	result := make([]domain.Pool, 0, len(r.pools))
+	for _, pool := range r.pools {
+		result = append(result, pool)
+	}
+	return result, nil
+}
+
+func (r *inMemoryPoolRepo) Save(_ context.Context, pool domain.Pool) error {
+	if r.pools == nil {
+		r.pools = map[domain.PoolID]domain.Pool{}
+	}
+	r.pools[pool.ID] = pool
+	return nil
+}
+
+type inMemoryAccountRepo struct {
+	accounts []domain.Account
+}
+
+func (r *inMemoryAccountRepo) GetByID(_ context.Context, id domain.AccountID) (domain.Account, error) {
+	for _, account := range r.accounts {
+		if account.ID == id {
+			return account, nil
+		}
+	}
+	return domain.Account{}, domain.ErrAccountNotFound
+}
+
+func (r *inMemoryAccountRepo) List(_ context.Context) ([]domain.Account, error) {
+	return r.accounts, nil
+}
+
+func (r *inMemoryAccountRepo) Save(_ context.Context, account domain.Account) error {
+	for i := range r.accounts {
+		if r.accounts[i].ID == account.ID {
+			r.accounts[i] = account
+			return nil
+		}
+	}
+	r.accounts = append(r.accounts, account)
+	return nil
+}
+
+type fixedClock struct {
+	now time.Time
+}
+
+func (f fixedClock) Now() time.Time {
+	return f.now
+}

--- a/internal/application/session_continuity_service.go
+++ b/internal/application/session_continuity_service.go
@@ -1,0 +1,137 @@
+package application
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/bnema/openai-accounts-cli/internal/domain"
+	"github.com/bnema/openai-accounts-cli/internal/ports"
+)
+
+type SessionContinuityService struct {
+	runtime ports.PoolRuntimeRepository
+	clock   ports.Clock
+}
+
+func NewSessionContinuityService(runtime ports.PoolRuntimeRepository, clock ports.Clock) *SessionContinuityService {
+	if clock == nil {
+		clock = ports.SystemClock{}
+	}
+
+	return &SessionContinuityService{runtime: runtime, clock: clock}
+}
+
+func (s *SessionContinuityService) ResolveLogicalSessionID(workspaceRoot, windowFingerprint string) string {
+	raw := strings.TrimSpace(workspaceRoot) + "|" + strings.TrimSpace(windowFingerprint)
+	hash := sha1.Sum([]byte(raw))
+	return hex.EncodeToString(hash[:])
+}
+
+func (s *SessionContinuityService) GetOrAttachAccountSession(ctx context.Context, poolID domain.PoolID, logicalSessionID string, accountID domain.AccountID) (string, bool, error) {
+	runtime, err := s.loadRuntime(ctx, poolID)
+	if err != nil {
+		return "", false, err
+	}
+
+	ledger := runtime.Sessions[logicalSessionID]
+	if ledger.LogicalSessionID == "" {
+		ledger.LogicalSessionID = logicalSessionID
+	}
+	if ledger.AccountSessions == nil {
+		ledger.AccountSessions = map[domain.AccountID]string{}
+	}
+
+	if sessionID, ok := ledger.AccountSessions[accountID]; ok && strings.TrimSpace(sessionID) != "" {
+		return sessionID, false, nil
+	}
+
+	sessionID, err := newProviderSessionID()
+	if err != nil {
+		return "", false, err
+	}
+	ledger.AccountSessions[accountID] = sessionID
+	runtime.Sessions[logicalSessionID] = ledger
+	runtime.ActiveAccountID = accountID
+	runtime.LastSyncedAt = s.clock.Now()
+
+	if err := s.runtime.Save(ctx, runtime); err != nil {
+		return "", false, fmt.Errorf("save pool runtime: %w", err)
+	}
+
+	return sessionID, true, nil
+}
+
+func (s *SessionContinuityService) UpdateMemoryPacket(ctx context.Context, poolID domain.PoolID, logicalSessionID string, memory domain.MemoryPacket) error {
+	runtime, err := s.loadRuntime(ctx, poolID)
+	if err != nil {
+		return err
+	}
+
+	ledger := runtime.Sessions[logicalSessionID]
+	if ledger.LogicalSessionID == "" {
+		ledger.LogicalSessionID = logicalSessionID
+	}
+	memory.UpdatedAt = s.clock.Now()
+	ledger.Memory = memory
+	runtime.Sessions[logicalSessionID] = ledger
+	runtime.LastSyncedAt = s.clock.Now()
+
+	if err := s.runtime.Save(ctx, runtime); err != nil {
+		return fmt.Errorf("save pool runtime: %w", err)
+	}
+
+	return nil
+}
+
+func (s *SessionContinuityService) GetActiveAccountID(ctx context.Context, poolID domain.PoolID) (domain.AccountID, error) {
+	runtime, err := s.loadRuntime(ctx, poolID)
+	if err != nil {
+		return "", err
+	}
+
+	return runtime.ActiveAccountID, nil
+}
+
+func (s *SessionContinuityService) SetActiveAccountID(ctx context.Context, poolID domain.PoolID, accountID domain.AccountID) error {
+	runtime, err := s.loadRuntime(ctx, poolID)
+	if err != nil {
+		return err
+	}
+
+	runtime.ActiveAccountID = accountID
+	runtime.LastSyncedAt = s.clock.Now()
+
+	if err := s.runtime.Save(ctx, runtime); err != nil {
+		return fmt.Errorf("save pool runtime: %w", err)
+	}
+
+	return nil
+}
+
+func (s *SessionContinuityService) loadRuntime(ctx context.Context, poolID domain.PoolID) (domain.PoolRuntime, error) {
+	runtime, err := s.runtime.GetByPoolID(ctx, poolID)
+	if err != nil {
+		if err != domain.ErrPoolNotFound {
+			return domain.PoolRuntime{}, err
+		}
+		runtime = domain.PoolRuntime{PoolID: poolID, Sessions: map[string]domain.SessionLedger{}}
+	}
+	if runtime.Sessions == nil {
+		runtime.Sessions = map[string]domain.SessionLedger{}
+	}
+
+	return runtime, nil
+}
+
+func newProviderSessionID() (string, error) {
+	raw := make([]byte, 16)
+	if _, err := rand.Read(raw); err != nil {
+		return "", fmt.Errorf("generate provider session id: %w", err)
+	}
+
+	return hex.EncodeToString(raw), nil
+}

--- a/internal/application/session_continuity_service_test.go
+++ b/internal/application/session_continuity_service_test.go
@@ -1,0 +1,99 @@
+package application
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/bnema/openai-accounts-cli/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSessionContinuityReuseMappedSession(t *testing.T) {
+	t.Parallel()
+
+	repo := &inMemoryPoolRuntimeRepo{runtimes: map[domain.PoolID]domain.PoolRuntime{
+		"default-openai": {
+			PoolID: "default-openai",
+			Sessions: map[string]domain.SessionLedger{
+				"proj-a": {
+					LogicalSessionID: "proj-a",
+					AccountSessions: map[domain.AccountID]string{
+						"2": "session-2",
+					},
+				},
+			},
+		},
+	}}
+
+	svc := NewSessionContinuityService(repo, fixedClock{now: time.Date(2026, 2, 28, 12, 0, 0, 0, time.UTC)})
+
+	sessionID, bootstrapped, err := svc.GetOrAttachAccountSession(context.Background(), "default-openai", "proj-a", "2")
+	require.NoError(t, err)
+	assert.Equal(t, "session-2", sessionID)
+	assert.False(t, bootstrapped)
+}
+
+func TestSessionContinuityBootstrapsMissingSessionAndSavesMemory(t *testing.T) {
+	t.Parallel()
+
+	repo := &inMemoryPoolRuntimeRepo{runtimes: map[domain.PoolID]domain.PoolRuntime{}}
+	svc := NewSessionContinuityService(repo, fixedClock{now: time.Date(2026, 2, 28, 12, 30, 0, 0, time.UTC)})
+
+	sessionID, bootstrapped, err := svc.GetOrAttachAccountSession(context.Background(), "default-openai", "proj-a", "3")
+	require.NoError(t, err)
+	assert.NotEqual(t, "proj-a:3", sessionID)
+	assert.NotContains(t, sessionID, "proj-a")
+	assert.NotContains(t, sessionID, ":3")
+	assert.True(t, bootstrapped)
+
+	err = svc.UpdateMemoryPacket(context.Background(), "default-openai", "proj-a", domain.MemoryPacket{
+		Summary:      "working on api",
+		Decisions:    []string{"use wrapper"},
+		PendingTasks: []string{"write tests"},
+		LastCodeRefs: []string{"cmd/run.go"},
+	})
+	require.NoError(t, err)
+
+	runtime, err := repo.GetByPoolID(context.Background(), "default-openai")
+	require.NoError(t, err)
+	ledger := runtime.Sessions["proj-a"]
+	assert.Equal(t, sessionID, ledger.AccountSessions["3"])
+	assert.Equal(t, "working on api", ledger.Memory.Summary)
+	require.False(t, ledger.Memory.UpdatedAt.IsZero())
+}
+
+func TestSessionContinuityResolveLogicalSessionPerWindow(t *testing.T) {
+	t.Parallel()
+
+	svc := NewSessionContinuityService(&inMemoryPoolRuntimeRepo{runtimes: map[domain.PoolID]domain.PoolRuntime{}}, fixedClock{now: time.Now()})
+
+	one := svc.ResolveLogicalSessionID("/repo/a", "window-1")
+	two := svc.ResolveLogicalSessionID("/repo/a", "window-2")
+	three := svc.ResolveLogicalSessionID("/repo/b", "window-1")
+
+	assert.NotEqual(t, one, two)
+	assert.NotEqual(t, one, three)
+	assert.NotEmpty(t, one)
+}
+
+type inMemoryPoolRuntimeRepo struct {
+	runtimes map[domain.PoolID]domain.PoolRuntime
+}
+
+func (r *inMemoryPoolRuntimeRepo) GetByPoolID(_ context.Context, poolID domain.PoolID) (domain.PoolRuntime, error) {
+	runtime, ok := r.runtimes[poolID]
+	if !ok {
+		return domain.PoolRuntime{}, domain.ErrPoolNotFound
+	}
+	return runtime, nil
+}
+
+func (r *inMemoryPoolRuntimeRepo) Save(_ context.Context, runtime domain.PoolRuntime) error {
+	if r.runtimes == nil {
+		r.runtimes = map[domain.PoolID]domain.PoolRuntime{}
+	}
+	r.runtimes[runtime.PoolID] = runtime
+	return nil
+}

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -4,5 +4,7 @@ import "errors"
 
 var (
 	ErrAccountNotFound = errors.New("account not found")
+	ErrPoolInactive    = errors.New("pool is deactivated")
+	ErrPoolNotFound    = errors.New("pool not found")
 	ErrSecretNotFound  = errors.New("secret not found")
 )

--- a/internal/domain/pool.go
+++ b/internal/domain/pool.go
@@ -1,0 +1,70 @@
+package domain
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+type PoolID string
+type Provider string
+type PoolStrategy string
+
+const (
+	ProviderOpenAI Provider = "openai"
+
+	PoolStrategyLeastWeeklyUsed PoolStrategy = "least_weekly_used"
+)
+
+type Pool struct {
+	ID              PoolID
+	Name            string
+	Provider        Provider
+	Strategy        PoolStrategy
+	Active          bool
+	AutoSyncMembers bool
+	Members         []AccountID
+	UpdatedAt       time.Time
+}
+
+func (p Pool) Validate() error {
+	if strings.TrimSpace(string(p.ID)) == "" {
+		return fmt.Errorf("id is required")
+	}
+	if strings.TrimSpace(p.Name) == "" {
+		return fmt.Errorf("name is required")
+	}
+	if strings.TrimSpace(string(p.Provider)) == "" {
+		return fmt.Errorf("provider is required")
+	}
+	if p.Provider != ProviderOpenAI {
+		return fmt.Errorf("unsupported provider %q", p.Provider)
+	}
+	if p.Strategy == "" {
+		return fmt.Errorf("strategy is required")
+	}
+
+	return nil
+}
+
+func (p *Pool) NormalizeMembers() {
+	if p == nil {
+		return
+	}
+
+	members := make([]AccountID, 0, len(p.Members))
+	seen := make(map[AccountID]struct{}, len(p.Members))
+	for _, member := range p.Members {
+		trimmed := AccountID(strings.TrimSpace(string(member)))
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		members = append(members, trimmed)
+	}
+
+	p.Members = members
+}

--- a/internal/domain/pool_session.go
+++ b/internal/domain/pool_session.go
@@ -1,0 +1,24 @@
+package domain
+
+import "time"
+
+type MemoryPacket struct {
+	Summary      string
+	Decisions    []string
+	PendingTasks []string
+	LastCodeRefs []string
+	UpdatedAt    time.Time
+}
+
+type SessionLedger struct {
+	LogicalSessionID string
+	AccountSessions  map[AccountID]string
+	Memory           MemoryPacket
+}
+
+type PoolRuntime struct {
+	PoolID          PoolID
+	ActiveAccountID AccountID
+	LastSyncedAt    time.Time
+	Sessions        map[string]SessionLedger
+}

--- a/internal/domain/pool_test.go
+++ b/internal/domain/pool_test.go
@@ -1,0 +1,59 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPoolValidate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		pool    Pool
+		wantErr string
+	}{
+		{
+			name: "valid",
+			pool: Pool{ID: "default-openai", Name: "default", Provider: ProviderOpenAI, Strategy: PoolStrategyLeastWeeklyUsed},
+		},
+		{
+			name:    "missing id",
+			pool:    Pool{Name: "default", Provider: ProviderOpenAI, Strategy: PoolStrategyLeastWeeklyUsed},
+			wantErr: "id is required",
+		},
+		{
+			name:    "missing provider",
+			pool:    Pool{ID: "default-openai", Name: "default", Strategy: PoolStrategyLeastWeeklyUsed},
+			wantErr: "provider is required",
+		},
+		{
+			name:    "unsupported provider",
+			pool:    Pool{ID: "default-openai", Name: "default", Provider: "foo", Strategy: PoolStrategyLeastWeeklyUsed},
+			wantErr: "unsupported provider",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := tc.pool.Validate()
+			if tc.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			assert.ErrorContains(t, err, tc.wantErr)
+		})
+	}
+}
+
+func TestPoolNormalizeMembersDeduplicatesAndDropsEmpty(t *testing.T) {
+	t.Parallel()
+
+	pool := Pool{Members: []AccountID{"1", "", "2", "1", "2", "3"}}
+	pool.NormalizeMembers()
+
+	assert.Equal(t, []AccountID{"1", "2", "3"}, pool.Members)
+}

--- a/internal/ports/pool_repository.go
+++ b/internal/ports/pool_repository.go
@@ -1,0 +1,18 @@
+package ports
+
+import (
+	"context"
+
+	"github.com/bnema/openai-accounts-cli/internal/domain"
+)
+
+type PoolRepository interface {
+	GetByID(ctx context.Context, id domain.PoolID) (domain.Pool, error)
+	List(ctx context.Context) ([]domain.Pool, error)
+	Save(ctx context.Context, pool domain.Pool) error
+}
+
+type PoolRuntimeRepository interface {
+	GetByPoolID(ctx context.Context, poolID domain.PoolID) (domain.PoolRuntime, error)
+	Save(ctx context.Context, runtime domain.PoolRuntime) error
+}


### PR DESCRIPTION
## Summary
- add OpenAI account pooling with `oa pool activate/deactivate/status/next/switch`
- add session continuity/runtime tracking and active account marker in usage output
- sync opencode auth during switching (`pool switch`, `pool next`, and `run opencode`)
- include tests and docs for pooling/switching behavior

## Privacy note
- this PR is submitted from a sanitized rewritten branch history with anonymized test fixture emails

## Test Plan
- [x] `go test ./...`