### PR TITLE
feat: add json output support and noctalia plugin prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Use it to keep multiple OpenAI accounts in one place, inspect their ChatGPT limi
 ```bash
 go install github.com/bnema/openai-accounts-cli/cmd/oa@latest
 # or from a clone
-make install
+go install ./cmd/oa
 ```
 
 ## Commands
@@ -137,10 +137,24 @@ oa sync --all --evenly
 | `OA_AUTH_LISTEN` | `127.0.0.1:1455` | Local callback listener |
 | `OA_USAGE_BASE_URL` | `https://chatgpt.com/backend-api` | Usage API base URL |
 
+## Noctalia plugin
+
+A local Noctalia plugin lives at `plugins/noctalia/oa-accounts`.
+
+Install it locally:
+
+```bash
+go install ./cmd/oa
+mkdir -p ~/.config/noctalia/plugins
+ln -sfn $(pwd)/plugins/noctalia/oa-accounts ~/.config/noctalia/plugins/oa-accounts
+```
+
+Then restart or reload Noctalia, enable **OpenAI Accounts** in the plugin manager if needed, and add its bar widget.
+
 ## Development
 
 ```bash
+go build -o oa ./cmd/oa
+go install ./cmd/oa
 go test ./...
-make build
-make install
 ```

--- a/README.md
+++ b/README.md
@@ -141,12 +141,13 @@ oa sync --all --evenly
 
 A local Noctalia plugin lives at `plugins/noctalia/oa-accounts`.
 
-Install it locally:
+Install it locally from the repository root:
 
 ```bash
 go install ./cmd/oa
 mkdir -p ~/.config/noctalia/plugins
-ln -sfn $(pwd)/plugins/noctalia/oa-accounts ~/.config/noctalia/plugins/oa-accounts
+PLUGIN_DIR="$(realpath plugins/noctalia/oa-accounts)"
+ln -sfn "$PLUGIN_DIR" ~/.config/noctalia/plugins/oa-accounts
 ```
 
 Then restart or reload Noctalia, enable **OpenAI Accounts** in the plugin manager if needed, and add its bar widget.

--- a/cmd/account.go
+++ b/cmd/account.go
@@ -11,6 +11,12 @@ func newAccountCmd(app *app) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "account",
 		Short: "Manage accounts",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if wantsJSON(cmd) {
+				return writeJSONError(cmd, fmt.Errorf("%s: subcommand required", cmd.CommandPath()))
+			}
+			return cmd.Help()
+		},
 	}
 
 	cmd.AddCommand(
@@ -28,7 +34,18 @@ func newAccountListCmd(app *app) *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			statuses, err := app.service.GetStatusAll(cmd.Context())
 			if err != nil {
-				return err
+				return writeJSONError(cmd, err)
+			}
+
+			if wantsJSON(cmd) {
+				accounts := make([]map[string]string, 0, len(statuses))
+				for _, status := range statuses {
+					accounts = append(accounts, map[string]string{
+						"id":   string(status.Account.ID),
+						"name": status.Account.Name,
+					})
+				}
+				return writeJSONOutput(cmd, map[string]any{"accounts": accounts})
 			}
 
 			for _, status := range statuses {
@@ -48,7 +65,10 @@ func newAccountRemoveCmd(app *app) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			id := domain.AccountID(args[0])
 			if err := app.service.RemoveAccount(cmd.Context(), id); err != nil {
-				return err
+				return writeJSONError(cmd, err)
+			}
+			if wantsJSON(cmd) {
+				return writeJSONOutput(cmd, map[string]any{"ok": true, "account_id": id})
 			}
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "account %s removed\n", id)
 			return nil

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -11,6 +11,12 @@ func newAuthCmd(app *app) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "auth",
 		Short: "Manage account authentication",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if wantsJSON(cmd) {
+				return writeJSONError(cmd, fmt.Errorf("%s: subcommand required", cmd.CommandPath()))
+			}
+			return cmd.Help()
+		},
 	}
 
 	cmd.AddCommand(newAuthSetCmd(app), newAuthRemoveCmd(app), newLoginCmd(app), newAuthCheckCmd(app))
@@ -30,20 +36,33 @@ func newAuthSetCmd(app *app) *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			authMethod, err := parseAuthMethod(method)
 			if err != nil {
-				return err
+				return writeJSONError(cmd, err)
 			}
 			resolvedAccountID, err := resolveAccountID(cmd.Context(), app, accountID)
 			if err != nil {
-				return err
+				return writeJSONError(cmd, err)
 			}
 
-			return app.service.SetAuth(
+			if err := app.service.SetAuth(
 				cmd.Context(),
 				resolvedAccountID,
 				authMethod,
 				secretKey,
 				secretValue,
-			)
+			); err != nil {
+				return writeJSONError(cmd, err)
+			}
+
+			if wantsJSON(cmd) {
+				return writeJSONOutput(cmd, map[string]any{
+					"ok":         true,
+					"account_id": resolvedAccountID,
+					"method":     authMethod,
+					"secret_key": secretKey,
+				})
+			}
+
+			return nil
 		},
 	}
 
@@ -65,7 +84,13 @@ func newAuthRemoveCmd(app *app) *cobra.Command {
 		Use:   "remove",
 		Short: "Remove account authentication",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return app.service.RemoveAuth(cmd.Context(), domain.AccountID(accountID))
+			if err := app.service.RemoveAuth(cmd.Context(), domain.AccountID(accountID)); err != nil {
+				return writeJSONError(cmd, err)
+			}
+			if wantsJSON(cmd) {
+				return writeJSONOutput(cmd, map[string]any{"ok": true, "account_id": accountID})
+			}
+			return nil
 		},
 	}
 

--- a/cmd/auth_check.go
+++ b/cmd/auth_check.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -41,7 +42,9 @@ func runAuthCheck(cmd *cobra.Command, app *app, accountID string) error {
 		if wantsJSON(cmd) {
 			return writeJSONOutput(cmd, map[string]any{"ok": true, "accounts": []any{}})
 		}
-		fmt.Fprintln(cmd.OutOrStdout(), "no ChatGPT accounts to check")
+		if _, err := fmt.Fprintln(cmd.OutOrStdout(), "no ChatGPT accounts to check"); err != nil {
+			return fmt.Errorf("write output: %w", err)
+		}
 		return nil
 	}
 
@@ -53,7 +56,12 @@ func runAuthCheck(cmd *cobra.Command, app *app, accountID string) error {
 		result, err := fetchAccountsConcurrently(ctx, app, accounts)
 		summary = result
 		if !wantsJSON(cmd) {
-			writeFetchSummaryPlain(cmd.ErrOrStderr(), result)
+			if writeErr := writeFetchSummaryPlain(cmd.ErrOrStderr(), result); writeErr != nil {
+				if err != nil {
+					return errors.Join(err, fmt.Errorf("write fetch summary: %w", writeErr))
+				}
+				return fmt.Errorf("write fetch summary: %w", writeErr)
+			}
 		}
 		return err
 	}
@@ -103,7 +111,9 @@ func runAuthCheck(cmd *cobra.Command, app *app, accountID string) error {
 				continue
 			}
 			// Error details already printed to stderr by fetchAccountsConcurrently.
-			fmt.Fprintf(cmd.OutOrStdout(), "account %s (%s): FAIL — see error above\n", status.Account.ID, label)
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "account %s (%s): FAIL — see error above\n", status.Account.ID, label); err != nil {
+				return fmt.Errorf("write output: %w", err)
+			}
 			continue
 		}
 
@@ -117,7 +127,9 @@ func runAuthCheck(cmd *cobra.Command, app *app, accountID string) error {
 			})
 			continue
 		}
-		fmt.Fprintf(cmd.OutOrStdout(), "account %s (%s): ok — %s\n", status.Account.ID, label, age)
+		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "account %s (%s): ok — %s\n", status.Account.ID, label, age); err != nil {
+			return fmt.Errorf("write output: %w", err)
+		}
 	}
 
 	if wantsJSON(cmd) {

--- a/cmd/auth_check.go
+++ b/cmd/auth_check.go
@@ -27,13 +27,20 @@ func newAuthCheckCmd(app *app) *cobra.Command {
 }
 
 func runAuthCheck(cmd *cobra.Command, app *app, accountID string) error {
+	if wantsJSON(cmd) {
+		cmd.Root().SilenceErrors = true
+	}
+
 	statuses, err := loadStatuses(cmd, app.service, accountID)
 	if err != nil {
-		return err
+		return writeJSONError(cmd, err)
 	}
 
 	accounts := filterChatGPTAccounts(statuses)
 	if len(accounts) == 0 {
+		if wantsJSON(cmd) {
+			return writeJSONOutput(cmd, map[string]any{"ok": true, "accounts": []any{}})
+		}
 		fmt.Fprintln(cmd.OutOrStdout(), "no ChatGPT accounts to check")
 		return nil
 	}
@@ -41,21 +48,35 @@ func runAuthCheck(cmd *cobra.Command, app *app, accountID string) error {
 	// Snapshot CapturedAt before fetch to detect which accounts actually updated.
 	beforeFetch := capturedAtSnapshot(statuses)
 
+	var summary fetchSummary
 	fetchFn := func(ctx context.Context) error {
-		return fetchAccountsConcurrently(ctx, app, accounts, cmd.ErrOrStderr())
+		result, err := fetchAccountsConcurrently(ctx, app, accounts)
+		summary = result
+		if !wantsJSON(cmd) {
+			writeFetchSummaryPlain(cmd.ErrOrStderr(), result)
+		}
+		return err
 	}
 
-	if err := runUsageFetchSpinner(cmd.Context(), cmd.ErrOrStderr(), "Checking auth...", fetchFn); err != nil {
-		return err
+	if wantsJSON(cmd) {
+		if err := fetchFn(cmd.Context()); err != nil {
+			return writeJSONError(cmd, err)
+		}
+	} else {
+		if err := runUsageFetchSpinner(cmd.Context(), cmd.ErrOrStderr(), "Checking auth...", fetchFn); err != nil {
+			return err
+		}
 	}
 
 	updated, err := loadStatuses(cmd, app.service, accountID)
 	if err != nil {
-		return err
+		return writeJSONError(cmd, err)
 	}
 
 	now := app.now()
 	var hasFailure bool
+	failureMessages := summary.errorByAccountID()
+	jsonAccounts := make([]map[string]any, 0, len(updated))
 	for _, status := range updated {
 		if status.Account.Auth.Method != domain.AuthMethodChatGPT {
 			continue
@@ -68,13 +89,45 @@ func runAuthCheck(cmd *cobra.Command, app *app, accountID string) error {
 
 		if !didFetchSucceed(status, beforeFetch) {
 			hasFailure = true
+			if wantsJSON(cmd) {
+				message := failureMessages[status.Account.ID]
+				if message == "" {
+					message = "authentication check failed"
+				}
+				jsonAccounts = append(jsonAccounts, map[string]any{
+					"account_id": status.Account.ID,
+					"name":       label,
+					"ok":         false,
+					"message":    message,
+				})
+				continue
+			}
 			// Error details already printed to stderr by fetchAccountsConcurrently.
 			fmt.Fprintf(cmd.OutOrStdout(), "account %s (%s): FAIL — see error above\n", status.Account.ID, label)
 			continue
 		}
 
 		age := formatFetchAge(status, now)
+		if wantsJSON(cmd) {
+			jsonAccounts = append(jsonAccounts, map[string]any{
+				"account_id": status.Account.ID,
+				"name":       label,
+				"ok":         true,
+				"message":    age,
+			})
+			continue
+		}
 		fmt.Fprintf(cmd.OutOrStdout(), "account %s (%s): ok — %s\n", status.Account.ID, label, age)
+	}
+
+	if wantsJSON(cmd) {
+		if err := writeJSONOutput(cmd, map[string]any{"ok": !hasFailure, "accounts": jsonAccounts}); err != nil {
+			return err
+		}
+		if hasFailure {
+			return renderedCommandError{err: fmt.Errorf("one or more accounts failed authentication check")}
+		}
+		return nil
 	}
 
 	if hasFailure {

--- a/cmd/cli_test.go
+++ b/cmd/cli_test.go
@@ -9,12 +9,14 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	statusadapter "github.com/bnema/openai-accounts-cli/internal/adapters/render/status"
 	"github.com/bnema/openai-accounts-cli/internal/application"
 	"github.com/bnema/openai-accounts-cli/internal/domain"
+	"github.com/bnema/openai-accounts-cli/internal/version"
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -33,6 +35,66 @@ func TestAuthSetRequiresSecretValueFlag(t *testing.T) {
 	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "required flag(s) \"secret-value\" not set")
+}
+
+func TestAuthSetRequiredFlagJSONErrorOutput(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t, writeAccountsFixture(home))
+
+	_, stderr, err := executeCLI(t, home,
+		"auth", "set",
+		"--account", "acc-1",
+		"--method", "api_key",
+		"--secret-key", "openai://acc-1/api_key",
+		"--json",
+	)
+	require.Error(t, err)
+	assert.JSONEq(t, `{"ok":false,"error":"required flag(s) \"secret-value\" not set"}`, stderr)
+}
+
+func TestUnknownCommandJSONErrorOutput(t *testing.T) {
+	home := t.TempDir()
+
+	_, stderr, err := executeCLI(t, home, "nosuch", "--json")
+	require.Error(t, err)
+	assert.JSONEq(t, `{"ok":false,"error":"unknown command \"nosuch\" for \"oa\""}`, stderr)
+}
+
+func TestRootJSONErrorWhenSubcommandMissing(t *testing.T) {
+	home := t.TempDir()
+
+	_, stderr, err := executeCLI(t, home, "--json")
+	require.Error(t, err)
+	assert.JSONEq(t, `{"ok":false,"error":"oa: subcommand required"}`, stderr)
+}
+
+func TestVersionJSONOutput(t *testing.T) {
+	home := t.TempDir()
+
+	stdout, stderr, err := executeCLI(t, home, "version", "--json")
+	require.NoError(t, err)
+	assert.Empty(t, stderr)
+	assert.JSONEq(t, fmt.Sprintf(`{"version":%q}`, version.Version), stdout)
+}
+
+func TestAccountListJSONOutput(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t, writeAccountsFixture(home))
+
+	stdout, stderr, err := executeCLI(t, home, "account", "list", "--json")
+	require.NoError(t, err)
+	assert.Empty(t, stderr)
+	assert.JSONEq(t, `{"accounts":[{"id":"acc-1","name":"Primary"}]}`, stdout)
+}
+
+func TestAccountRemoveJSONOutput(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t, writeAccountsFixture(home))
+
+	stdout, stderr, err := executeCLI(t, home, "account", "remove", "acc-1", "--json")
+	require.NoError(t, err)
+	assert.Empty(t, stderr)
+	assert.JSONEq(t, `{"ok":true,"account_id":"acc-1"}`, stdout)
 }
 
 func TestStatusByAccountHappyPath(t *testing.T) {
@@ -74,6 +136,42 @@ func TestAuthSetThenStatusShowsAuthMethod(t *testing.T) {
 	assert.Contains(t, stdout, "Primary (acc-1)")
 }
 
+func TestAuthSetJSONOutput(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t, writeAccountsFixture(home))
+
+	stdout, stderr, err := executeCLI(t, home,
+		"auth", "set",
+		"--account", "acc-1",
+		"--method", "api_key",
+		"--secret-key", "openai://acc-1/api_key",
+		"--secret-value", "test-secret-value",
+		"--json",
+	)
+	require.NoError(t, err)
+	assert.Empty(t, stderr)
+	assert.JSONEq(t, `{"ok":true,"account_id":"acc-1","method":"api_key","secret_key":"openai://acc-1/api_key"}`, stdout)
+}
+
+func TestAuthRemoveJSONOutput(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t, writeAccountsFixture(home))
+
+	_, _, err := executeCLI(t, home,
+		"auth", "set",
+		"--account", "acc-1",
+		"--method", "api_key",
+		"--secret-key", "openai://acc-1/api_key",
+		"--secret-value", "test-secret-value",
+	)
+	require.NoError(t, err)
+
+	stdout, stderr, err := executeCLI(t, home, "auth", "remove", "--account", "acc-1", "--json")
+	require.NoError(t, err)
+	assert.Empty(t, stderr)
+	assert.JSONEq(t, `{"ok":true,"account_id":"acc-1"}`, stdout)
+}
+
 func TestAuthSetAutoAssignsNextNumericAccountID(t *testing.T) {
 	home := t.TempDir()
 	require.NoError(t, writeAccountsFixture(home))
@@ -107,6 +205,15 @@ func TestLoginDeviceReturnsNotImplemented(t *testing.T) {
 	_, _, err := executeCLI(t, home, "auth", "login", "device")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not implemented yet")
+}
+
+func TestLoginDeviceJSONErrorOutput(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t, writeAccountsFixture(home))
+
+	_, stderr, err := executeCLI(t, home, "auth", "login", "device", "--json")
+	require.Error(t, err)
+	assert.JSONEq(t, `{"ok":false,"error":"oa auth login device for account 1: not implemented yet"}`, stderr)
 }
 
 func TestLimitCommandIsRemoved(t *testing.T) {
@@ -306,6 +413,15 @@ func TestPiInstallWritesAuthHotReloadExtension(t *testing.T) {
 	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
 }
 
+func TestPiInstallJSONOutput(t *testing.T) {
+	home := t.TempDir()
+
+	stdout, stderr, err := executeCLI(t, home, "install", "pi", "--json")
+	require.NoError(t, err)
+	assert.Empty(t, stderr)
+	assert.JSONEq(t, fmt.Sprintf(`{"ok":true,"path":%q,"reload_command":"/reload"}`, filepath.Join(home, ".pi", "agent", "extensions", "oa-auth-hot-reload.ts")), stdout)
+}
+
 func TestOpencodeInstallWritesPluginAndConfig(t *testing.T) {
 	home := t.TempDir()
 
@@ -363,6 +479,21 @@ func TestOpencodeDoctorReportsHealthyInstall(t *testing.T) {
 	assert.Contains(t, stdout, "account repo: ok accounts: 1")
 }
 
+func TestOpencodeDoctorJSONOutput(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t, writeAccountsFixture(home))
+	binDir := writeFakeOABinary(t)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	_, _, err := executeCLI(t, home, "install", "opencode")
+	require.NoError(t, err)
+
+	stdout, stderr, err := executeCLI(t, home, "opencode", "doctor", "--json")
+	require.NoError(t, err)
+	assert.Empty(t, stderr)
+	assert.JSONEq(t, `{"checks":[{"name":"plugin","status":"ok","detail":""},{"name":"oa binary","status":"ok","detail":""},{"name":"auth file","status":"missing","detail":""},{"name":"account repo","status":"ok","detail":"accounts: 1"}]}`, stdout)
+}
+
 func TestOpencodeDoctorReportsMissingOABinaryWhenNotOnPATH(t *testing.T) {
 	home := t.TempDir()
 	require.NoError(t, writeAccountsFixture(home))
@@ -418,6 +549,121 @@ func TestOpencodeSyncSelectsBestEligibleAccountAndWritesOpenAIAuthEntry(t *testi
 	assert.NotContains(t, string(data), `"codex"`)
 }
 
+func TestOpencodeSyncJSONOutput(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t, writeOpencodeSyncAccountsFixture(home))
+
+	_, _, err := executeCLI(t, home,
+		"auth", "set",
+		"--account", "acc-2",
+		"--method", "chatgpt",
+		"--secret-key", "openai://acc-2/oauth_tokens",
+		"--secret-value", fmt.Sprintf(`{"access_token":"access-token-222","refresh_token":"refresh-token-222","id_token":%q,"expires_at":1890000000}`, fakeJWT(`{"chatgpt_account_id":"chatgpt-account-2"}`)),
+	)
+	require.NoError(t, err)
+	_, _, err = executeCLI(t, home,
+		"auth", "set",
+		"--account", "acc-3",
+		"--method", "chatgpt",
+		"--secret-key", "openai://acc-3/oauth_tokens",
+		"--secret-value", fmt.Sprintf(`{"access_token":"access-token-333","refresh_token":"refresh-token-333","id_token":%q,"expires_at":1890000000}`, fakeJWT(`{"chatgpt_account_id":"chatgpt-account-3"}`)),
+	)
+	require.NoError(t, err)
+
+	stdout, stderr, err := executeCLI(t, home, "sync", "opencode", "--json")
+	require.NoError(t, err)
+	assert.Empty(t, stderr)
+	assert.JSONEq(t, `{"ok":true,"target":"opencode","account_id":"acc-3","account_name":"Best"}`, stdout)
+}
+
+func TestOpencodeSyncAliasJSONOutput(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t, writeOpencodeSyncAccountsFixture(home))
+
+	_, _, err := executeCLI(t, home,
+		"auth", "set",
+		"--account", "acc-2",
+		"--method", "chatgpt",
+		"--secret-key", "openai://acc-2/oauth_tokens",
+		"--secret-value", fmt.Sprintf(`{"access_token":"access-token-222","refresh_token":"refresh-token-222","id_token":%q,"expires_at":1890000000}`, fakeJWT(`{"chatgpt_account_id":"chatgpt-account-2"}`)),
+	)
+	require.NoError(t, err)
+	_, _, err = executeCLI(t, home,
+		"auth", "set",
+		"--account", "acc-3",
+		"--method", "chatgpt",
+		"--secret-key", "openai://acc-3/oauth_tokens",
+		"--secret-value", fmt.Sprintf(`{"access_token":"access-token-333","refresh_token":"refresh-token-333","id_token":%q,"expires_at":1890000000}`, fakeJWT(`{"chatgpt_account_id":"chatgpt-account-3"}`)),
+	)
+	require.NoError(t, err)
+
+	stdout, stderr, err := executeCLI(t, home, "opencode", "sync", "--json")
+	require.NoError(t, err)
+	assert.Empty(t, stderr)
+	assert.JSONEq(t, `{"ok":true,"target":"opencode","account_id":"acc-3","account_name":"Best"}`, stdout)
+}
+
+func TestOpencodeSyncJSONIncludesFetchWarnings(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+		switch token {
+		case "good-token":
+			_, _ = fmt.Fprint(w, `{"plan_type":"pro","rate_limit":{"primary_window":{"used_percent":21,"limit_window_seconds":18000,"reset_at":1893456000},"secondary_window":{"used_percent":47,"limit_window_seconds":604800,"reset_at":1893888000}}}`)
+		case "bad-token":
+			w.WriteHeader(http.StatusBadGateway)
+			_, _ = fmt.Fprint(w, `{"error":"temporary_failure"}`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("OA_USAGE_BASE_URL", server.URL)
+
+	home := t.TempDir()
+	require.NoError(t, writeOpencodeSyncAccountsFixture(home))
+
+	_, _, err := executeCLI(t, home,
+		"auth", "set",
+		"--account", "acc-2",
+		"--method", "chatgpt",
+		"--secret-key", "openai://acc-2/oauth_tokens",
+		"--secret-value", fmt.Sprintf(`{"access_token":"bad-token","refresh_token":"refresh-token-222","id_token":%q,"expires_at":4102444800}`, fakeJWT(`{"chatgpt_account_id":"chatgpt-account-2"}`)),
+	)
+	require.NoError(t, err)
+	_, _, err = executeCLI(t, home,
+		"auth", "set",
+		"--account", "acc-3",
+		"--method", "chatgpt",
+		"--secret-key", "openai://acc-3/oauth_tokens",
+		"--secret-value", fmt.Sprintf(`{"access_token":"good-token","refresh_token":"refresh-token-333","id_token":%q,"expires_at":4102444800}`, fakeJWT(`{"chatgpt_account_id":"chatgpt-account-3"}`)),
+	)
+	require.NoError(t, err)
+
+	stdout, stderr, err := executeCLIWithHomeAndApp(t, home, func(app *app) {
+		app.now = func() time.Time {
+			return time.Date(2099, 4, 5, 12, 10, 0, 0, time.UTC)
+		}
+	}, "sync", "opencode", "--json")
+	require.NoError(t, err)
+	assert.Empty(t, stderr)
+
+	var payload struct {
+		OK       bool   `json:"ok"`
+		Target   string `json:"target"`
+		Warnings []struct {
+			AccountID string `json:"account_id"`
+			Error     string `json:"error"`
+		} `json:"warnings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &payload))
+	assert.True(t, payload.OK)
+	assert.Equal(t, "opencode", payload.Target)
+	require.Len(t, payload.Warnings, 1)
+	assert.Equal(t, "acc-2", payload.Warnings[0].AccountID)
+	assert.Contains(t, payload.Warnings[0].Error, "fetch usage")
+}
+
 func TestOpencodeSyncForceAccountIDOverridesBestEligibleAccount(t *testing.T) {
 	home := t.TempDir()
 	require.NoError(t, writeOpencodeSyncAccountsFixture(home))
@@ -449,6 +695,25 @@ func TestOpencodeSyncForceAccountIDOverridesBestEligibleAccount(t *testing.T) {
 	require.NoError(t, readErr)
 	assert.Contains(t, string(data), `"accountId": "chatgpt-account-2"`)
 	assert.NotContains(t, string(data), "chatgpt-account-3")
+}
+
+func TestSyncAllJSONOutput(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t, writeOpencodeSingleSyncAccountFixture(home, "acc-2", "Top Choice"))
+
+	_, _, err := executeCLI(t, home,
+		"auth", "set",
+		"--account", "acc-2",
+		"--method", "chatgpt",
+		"--secret-key", "openai://acc-2/oauth_tokens",
+		"--secret-value", fmt.Sprintf(`{"access_token":"access-token-222","refresh_token":"refresh-token-222","id_token":%q,"expires_at":1890000000}`, fakeJWT(`{"chatgpt_account_id":"chatgpt-account-2"}`)),
+	)
+	require.NoError(t, err)
+
+	stdout, stderr, err := executeCLI(t, home, "sync", "--all", "--json")
+	require.NoError(t, err)
+	assert.Empty(t, stderr)
+	assert.JSONEq(t, `{"ok":true,"targets":["opencode","codex","pi"],"account_id":"acc-2","account_name":"Top Choice"}`, stdout)
 }
 
 func TestOpencodeSyncForceAccountIDDoesNotFallBackWhenForcedAccountIsUnavailable(t *testing.T) {
@@ -603,6 +868,18 @@ func TestOpencodeInstallSystemdWritesUserUnits(t *testing.T) {
 	assert.Contains(t, string(serviceData), " sync opencode")
 	assert.Contains(t, string(timerData), "OnUnitActiveSec=10m")
 	assert.Contains(t, string(timerData), "WantedBy=timers.target")
+}
+
+func TestOpencodeInstallSystemdJSONOutput(t *testing.T) {
+	home := t.TempDir()
+
+	stdout, stderr, err := executeCLI(t, home, "opencode", "install-systemd", "--json")
+	require.NoError(t, err)
+	assert.Empty(t, stderr)
+	assert.JSONEq(t, fmt.Sprintf(`{"ok":true,"unit_dir":%q,"service_path":%q,"timer_path":%q,"timer":"oa-opencode-sync.timer"}`,
+		filepath.Join(home, ".config", "systemd", "user"),
+		filepath.Join(home, ".config", "systemd", "user", "oa-opencode-sync.service"),
+		filepath.Join(home, ".config", "systemd", "user", "oa-opencode-sync.timer")), stdout)
 }
 
 func TestRenderOpencodeSystemdServiceQuotesExecutablePath(t *testing.T) {
@@ -1101,6 +1378,63 @@ func TestUsageCommandJSONOutput(t *testing.T) {
 	assert.Contains(t, stdout, "\"WeeklyLimit\"")
 }
 
+func TestUsageCommandJSONWarnsOnPartialFetchFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+		switch token {
+		case "good-token":
+			_, _ = fmt.Fprint(w, `{"plan_type":"pro","rate_limit":{"primary_window":{"used_percent":21,"limit_window_seconds":18000,"reset_at":1893456000},"secondary_window":{"used_percent":47,"limit_window_seconds":604800,"reset_at":1893888000}}}`)
+		case "bad-token":
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = fmt.Fprint(w, `{"error":"invalid_token"}`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("OA_USAGE_BASE_URL", server.URL)
+
+	home := t.TempDir()
+	require.NoError(t, writeOpencodeSyncAccountsFixture(home))
+
+	_, _, err := executeCLI(t, home,
+		"auth", "set",
+		"--account", "acc-2",
+		"--method", "chatgpt",
+		"--secret-key", "openai://acc-2/oauth_tokens",
+		"--secret-value", `{"access_token":"bad-token","refresh_token":"","id_token":""}`,
+	)
+	require.NoError(t, err)
+	_, _, err = executeCLI(t, home,
+		"auth", "set",
+		"--account", "acc-3",
+		"--method", "chatgpt",
+		"--secret-key", "openai://acc-3/oauth_tokens",
+		"--secret-value", `{"access_token":"good-token","refresh_token":"","id_token":""}`,
+	)
+	require.NoError(t, err)
+
+	stdout, stderr, err := executeCLIWithHomeAndApp(t, home, func(app *app) {
+		app.now = func() time.Time {
+			return time.Date(2099, 4, 5, 12, 10, 0, 0, time.UTC)
+		}
+	}, "usage", "--json")
+	require.NoError(t, err)
+	assert.True(t, json.Valid([]byte(stdout)))
+
+	var warnings struct {
+		Warnings []struct {
+			AccountID string `json:"account_id"`
+			Error     string `json:"error"`
+		} `json:"warnings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stderr), &warnings))
+	require.Len(t, warnings.Warnings, 1)
+	assert.Equal(t, "acc-2", warnings.Warnings[0].AccountID)
+	assert.Contains(t, warnings.Warnings[0].Error, "session expired")
+}
+
 func TestUsageCommandPassesSharedRecommendationToRenderer(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
@@ -1441,7 +1775,7 @@ func executeCLI(t *testing.T, home string, args ...string) (string, string, erro
 	root.SetErr(stderr)
 	root.SetArgs(args)
 
-	executeErr := root.Execute()
+	executeErr := executeRootCommand(root, args)
 	return stdout.String(), stderr.String(), executeErr
 }
 
@@ -1457,7 +1791,7 @@ func executeCLIWithStdin(t *testing.T, home, stdin string, args ...string) (stri
 	root.SetErr(stderr)
 	root.SetArgs(args)
 
-	executeErr := root.Execute()
+	executeErr := executeRootCommand(root, args)
 	return stdout.String(), stderr.String(), executeErr
 }
 
@@ -1478,7 +1812,7 @@ func executeCLIWithHomeAndApp(t *testing.T, home string, configure func(*app), a
 	root.SetErr(stderr)
 	root.SetArgs(args)
 
-	executeErr := root.Execute()
+	executeErr := executeRootCommand(root, args)
 	return stdout.String(), stderr.String(), executeErr
 }
 
@@ -1914,6 +2248,115 @@ func TestAuthCheckReportsOKAfterSuccessfulFetch(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, stdout, "ok")
 	assert.Contains(t, stdout, "acc-1")
+}
+
+func TestAuthCheckJSONOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/wham/usage" {
+			_, _ = fmt.Fprint(w, `{"plan_type":"pro","rate_limit":{"primary_window":{"used_percent":20,"limit_window_seconds":18000,"reset_at":1893456000},"secondary_window":{"used_percent":50,"limit_window_seconds":604800,"reset_at":1893888000}}}`)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	t.Setenv("OA_USAGE_BASE_URL", server.URL)
+
+	home := t.TempDir()
+	require.NoError(t, writeAccountsFixture(home))
+
+	_, _, err := executeCLI(t, home,
+		"auth", "set",
+		"--account", "acc-1",
+		"--method", "chatgpt",
+		"--secret-key", "openai://acc-1/oauth_tokens",
+		"--secret-value", `{"access_token":"valid-token","id_token":""}`,
+	)
+	require.NoError(t, err)
+
+	stdout, stderr, err := executeCLI(t, home, "auth", "check", "--account", "acc-1", "--json")
+	require.NoError(t, err)
+	assert.Empty(t, stderr)
+
+	var payload struct {
+		OK       bool `json:"ok"`
+		Accounts []struct {
+			AccountID string `json:"account_id"`
+			Name      string `json:"name"`
+			OK        bool   `json:"ok"`
+			Message   string `json:"message"`
+		} `json:"accounts"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &payload))
+	assert.True(t, payload.OK)
+	require.Len(t, payload.Accounts, 1)
+	assert.Equal(t, "acc-1", payload.Accounts[0].AccountID)
+	assert.Equal(t, "Primary", payload.Accounts[0].Name)
+	assert.True(t, payload.Accounts[0].OK)
+	assert.Contains(t, payload.Accounts[0].Message, "data fetched")
+}
+
+func TestAuthCheckJSONFailureIncludesAccountMessage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+		switch token {
+		case "good-token":
+			_, _ = fmt.Fprint(w, `{"plan_type":"pro","rate_limit":{"primary_window":{"used_percent":20,"limit_window_seconds":18000,"reset_at":1893456000},"secondary_window":{"used_percent":50,"limit_window_seconds":604800,"reset_at":1893888000}}}`)
+		case "bad-token":
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = fmt.Fprint(w, `{"error":"invalid_token"}`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("OA_USAGE_BASE_URL", server.URL)
+
+	home := t.TempDir()
+	require.NoError(t, writeOpencodeSyncAccountsFixture(home))
+
+	_, _, err := executeCLI(t, home,
+		"auth", "set",
+		"--account", "acc-2",
+		"--method", "chatgpt",
+		"--secret-key", "openai://acc-2/oauth_tokens",
+		"--secret-value", `{"access_token":"bad-token","refresh_token":"","id_token":""}`,
+	)
+	require.NoError(t, err)
+	_, _, err = executeCLI(t, home,
+		"auth", "set",
+		"--account", "acc-3",
+		"--method", "chatgpt",
+		"--secret-key", "openai://acc-3/oauth_tokens",
+		"--secret-value", `{"access_token":"good-token","refresh_token":"","id_token":""}`,
+	)
+	require.NoError(t, err)
+
+	stdout, stderr, err := executeCLIWithHomeAndApp(t, home, func(app *app) {
+		app.now = func() time.Time {
+			return time.Date(2099, 4, 5, 12, 10, 0, 0, time.UTC)
+		}
+	}, "auth", "check", "--json")
+	require.Error(t, err)
+	assert.Empty(t, stderr)
+
+	var payload struct {
+		OK       bool `json:"ok"`
+		Accounts []struct {
+			AccountID string `json:"account_id"`
+			OK        bool   `json:"ok"`
+			Message   string `json:"message"`
+		} `json:"accounts"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &payload))
+	assert.False(t, payload.OK)
+	require.Len(t, payload.Accounts, 2)
+	assert.Equal(t, "acc-2", payload.Accounts[0].AccountID)
+	assert.False(t, payload.Accounts[0].OK)
+	assert.Contains(t, payload.Accounts[0].Message, "session expired")
+	assert.Equal(t, "acc-3", payload.Accounts[1].AccountID)
+	assert.True(t, payload.Accounts[1].OK)
 }
 
 func TestAuthCheckSkipsNonChatGPTAccount(t *testing.T) {

--- a/cmd/cli_test.go
+++ b/cmd/cli_test.go
@@ -87,6 +87,136 @@ func TestAccountListJSONOutput(t *testing.T) {
 	assert.JSONEq(t, `{"accounts":[{"id":"acc-1","name":"Primary"}]}`, stdout)
 }
 
+func TestNoctaliaSnapshotJSONOutput(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t, writeOpencodeSyncAccountsFixture(home))
+
+	stdout, stderr, err := executeCLIWithHomeAndApp(t, home, func(app *app) {
+		app.now = func() time.Time {
+			return time.Date(2099, 4, 5, 12, 10, 0, 0, time.UTC)
+		}
+	}, "noctalia", "snapshot", "--json")
+	require.NoError(t, err)
+	assert.Empty(t, stderr)
+
+	var payload struct {
+		SchemaVersion  int      `json:"schema_version"`
+		RefreshCommand []string `json:"refresh_command"`
+		Recommendation struct {
+			Available   bool   `json:"available"`
+			AccountID   string `json:"account_id"`
+			AccountName string `json:"account_name"`
+			Rank        int    `json:"rank"`
+		} `json:"recommendation"`
+		Accounts []struct {
+			ID             string `json:"id"`
+			Name           string `json:"name"`
+			AuthConfigured bool   `json:"auth_configured"`
+			Recommendation struct {
+				Selected bool `json:"selected"`
+				Eligible bool `json:"eligible"`
+				Rank     int  `json:"rank"`
+			} `json:"recommendation"`
+			Daily *struct {
+				PercentUsed float64 `json:"percent_used"`
+			} `json:"daily"`
+		} `json:"accounts"`
+		SyncTargets []struct {
+			ID      string   `json:"id"`
+			Command []string `json:"command"`
+		} `json:"sync_targets"`
+		Warnings []any `json:"warnings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &payload))
+	assert.Equal(t, 1, payload.SchemaVersion)
+	assert.Equal(t, []string{"noctalia", "snapshot", "--json", "--refresh"}, payload.RefreshCommand)
+	assert.True(t, payload.Recommendation.Available)
+	assert.Equal(t, "acc-3", payload.Recommendation.AccountID)
+	assert.Equal(t, "Best", payload.Recommendation.AccountName)
+	assert.Equal(t, 1, payload.Recommendation.Rank)
+	require.Len(t, payload.Accounts, 3)
+	assert.Equal(t, "acc-1", payload.Accounts[0].ID)
+	assert.False(t, payload.Accounts[0].AuthConfigured)
+	assert.Equal(t, "acc-3", payload.Accounts[2].ID)
+	assert.True(t, payload.Accounts[2].Recommendation.Selected)
+	assert.True(t, payload.Accounts[2].Recommendation.Eligible)
+	assert.Equal(t, 1, payload.Accounts[2].Recommendation.Rank)
+	require.NotNil(t, payload.Accounts[2].Daily)
+	assert.Equal(t, 15.0, payload.Accounts[2].Daily.PercentUsed)
+	require.Len(t, payload.SyncTargets, 4)
+	assert.Equal(t, "opencode", payload.SyncTargets[0].ID)
+	assert.Equal(t, []string{"sync", "opencode", "--json"}, payload.SyncTargets[0].Command)
+	assert.Equal(t, "all", payload.SyncTargets[3].ID)
+	assert.Equal(t, []string{"sync", "--all", "--json"}, payload.SyncTargets[3].Command)
+	assert.Empty(t, payload.Warnings)
+}
+
+func TestNoctaliaSnapshotRefreshJSONIncludesWarnings(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+		switch {
+		case r.URL.Path == "/wham/usage" && token == "good-token":
+			_, _ = fmt.Fprint(w, `{"plan_type":"pro","rate_limit":{"primary_window":{"used_percent":21,"limit_window_seconds":18000,"reset_at":1893456000},"secondary_window":{"used_percent":47,"limit_window_seconds":604800,"reset_at":1893888000}}}`)
+		case r.URL.Path == "/wham/usage" && token == "bad-token":
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = fmt.Fprint(w, `{"error":"invalid_token"}`)
+		case strings.HasPrefix(r.URL.Path, "/subscriptions") && token == "good-token":
+			_, _ = fmt.Fprint(w, `{"plan_type":"pro","active_start":"2099-04-01T00:00:00Z","active_until":"2099-05-01T00:00:00Z","will_renew":true,"billing_period":"monthly","billing_currency":"USD","is_delinquent":false}`)
+		case strings.HasPrefix(r.URL.Path, "/subscriptions") && token == "bad-token":
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = fmt.Fprint(w, `{"error":"invalid_token"}`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("OA_USAGE_BASE_URL", server.URL)
+
+	home := t.TempDir()
+	require.NoError(t, writeOpencodeSyncAccountsFixture(home))
+
+	_, _, err := executeCLI(t, home,
+		"auth", "set",
+		"--account", "acc-2",
+		"--method", "chatgpt",
+		"--secret-key", "openai://acc-2/oauth_tokens",
+		"--secret-value", fmt.Sprintf(`{"access_token":"bad-token","refresh_token":"refresh-token-222","id_token":%q,"expires_at":4102444800}`, fakeJWT(`{"chatgpt_account_id":"chatgpt-account-2"}`)),
+	)
+	require.NoError(t, err)
+	_, _, err = executeCLI(t, home,
+		"auth", "set",
+		"--account", "acc-3",
+		"--method", "chatgpt",
+		"--secret-key", "openai://acc-3/oauth_tokens",
+		"--secret-value", fmt.Sprintf(`{"access_token":"good-token","refresh_token":"refresh-token-333","id_token":%q,"expires_at":4102444800}`, fakeJWT(`{"chatgpt_account_id":"chatgpt-account-3"}`)),
+	)
+	require.NoError(t, err)
+
+	stdout, stderr, err := executeCLIWithHomeAndApp(t, home, func(app *app) {
+		app.now = func() time.Time {
+			return time.Date(2099, 4, 5, 12, 10, 0, 0, time.UTC)
+		}
+	}, "noctalia", "snapshot", "--json", "--refresh")
+	require.NoError(t, err)
+	assert.Empty(t, stderr)
+
+	var payload struct {
+		Recommendation struct {
+			AccountID string `json:"account_id"`
+		} `json:"recommendation"`
+		Warnings []struct {
+			AccountID string `json:"account_id"`
+			Message   string `json:"message"`
+		} `json:"warnings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &payload))
+	assert.Equal(t, "acc-3", payload.Recommendation.AccountID)
+	require.Len(t, payload.Warnings, 1)
+	assert.Equal(t, "acc-2", payload.Warnings[0].AccountID)
+	assert.Contains(t, payload.Warnings[0].Message, "refresh oauth tokens")
+}
+
 func TestAccountRemoveJSONOutput(t *testing.T) {
 	home := t.TempDir()
 	require.NoError(t, writeAccountsFixture(home))

--- a/cmd/json_output.go
+++ b/cmd/json_output.go
@@ -1,0 +1,137 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+type jsonErrorOutput struct {
+	OK    bool   `json:"ok"`
+	Error string `json:"error"`
+}
+
+type renderedCommandError struct {
+	err error
+}
+
+func (e renderedCommandError) Error() string {
+	if e.err == nil {
+		return ""
+	}
+	return e.err.Error()
+}
+
+func (e renderedCommandError) Unwrap() error {
+	return e.err
+}
+
+func wantsJSON(cmd *cobra.Command) bool {
+	if cmd == nil {
+		return false
+	}
+
+	flag := cmd.Flags().Lookup("json")
+	if flag == nil {
+		flag = cmd.InheritedFlags().Lookup("json")
+	}
+	if flag == nil {
+		return false
+	}
+
+	enabled, err := strconv.ParseBool(flag.Value.String())
+	if err != nil {
+		return false
+	}
+
+	return enabled
+}
+
+func writeJSONOutput(cmd *cobra.Command, payload any) error {
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(payload)
+}
+
+func writeCompactJSONOutput(cmd *cobra.Command, payload any) error {
+	return json.NewEncoder(cmd.OutOrStdout()).Encode(payload)
+}
+
+func writeJSONError(cmd *cobra.Command, err error) error {
+	if err == nil {
+		return nil
+	}
+
+	if wantsJSON(cmd) {
+		encodeErr := json.NewEncoder(cmd.ErrOrStderr()).Encode(jsonErrorOutput{
+			OK:    false,
+			Error: err.Error(),
+		})
+		if encodeErr != nil {
+			return encodeErr
+		}
+		return renderedCommandError{err: err}
+	}
+
+	return err
+}
+
+func commandRequestedJSON(cmd *cobra.Command, args []string) bool {
+	if wantsJSON(cmd) {
+		return true
+	}
+
+	for _, arg := range args {
+		if arg == "--json" {
+			return true
+		}
+		if !strings.HasPrefix(arg, "--json=") {
+			continue
+		}
+		enabled, err := strconv.ParseBool(strings.TrimPrefix(arg, "--json="))
+		if err == nil {
+			return enabled
+		}
+	}
+
+	return false
+}
+
+func executeRootCommand(root *cobra.Command, args []string) error {
+	if root == nil {
+		return nil
+	}
+
+	root.SilenceErrors = true
+
+	err := root.Execute()
+	if err == nil {
+		return nil
+	}
+
+	var rendered renderedCommandError
+	if errors.As(err, &rendered) {
+		return rendered.Unwrap()
+	}
+
+	if commandRequestedJSON(root, args) {
+		encodeErr := json.NewEncoder(root.ErrOrStderr()).Encode(jsonErrorOutput{
+			OK:    false,
+			Error: err.Error(),
+		})
+		if encodeErr != nil {
+			return encodeErr
+		}
+		return err
+	}
+
+	if _, printErr := fmt.Fprintf(root.ErrOrStderr(), "Error: %v\n", err); printErr != nil {
+		return printErr
+	}
+
+	return err
+}

--- a/cmd/json_output.go
+++ b/cmd/json_output.go
@@ -86,17 +86,25 @@ func commandRequestedJSON(cmd *cobra.Command, args []string) bool {
 		return true
 	}
 
+	found := false
+	enabled := false
 	for _, arg := range args {
-		if arg == "--json" {
-			return true
+		switch {
+		case arg == "--json":
+			found = true
+			enabled = true
+		case strings.HasPrefix(arg, "--json="):
+			parsed, err := strconv.ParseBool(strings.TrimPrefix(arg, "--json="))
+			if err != nil {
+				continue
+			}
+			found = true
+			enabled = parsed
 		}
-		if !strings.HasPrefix(arg, "--json=") {
-			continue
-		}
-		enabled, err := strconv.ParseBool(strings.TrimPrefix(arg, "--json="))
-		if err == nil {
-			return enabled
-		}
+	}
+
+	if found {
+		return enabled
 	}
 
 	return false
@@ -108,6 +116,11 @@ func executeRootCommand(root *cobra.Command, args []string) error {
 	}
 
 	root.SilenceErrors = true
+	if args == nil {
+		root.SetArgs([]string{})
+	} else {
+		root.SetArgs(args)
+	}
 
 	err := root.Execute()
 	if err == nil {

--- a/cmd/json_output.go
+++ b/cmd/json_output.go
@@ -72,7 +72,8 @@ func writeJSONError(cmd *cobra.Command, err error) error {
 			Error: err.Error(),
 		})
 		if encodeErr != nil {
-			return encodeErr
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "failed to encode JSON error: %v\n", encodeErr)
+			return renderedCommandError{err: err}
 		}
 		return renderedCommandError{err: err}
 	}
@@ -124,7 +125,8 @@ func executeRootCommand(root *cobra.Command, args []string) error {
 			Error: err.Error(),
 		})
 		if encodeErr != nil {
-			return encodeErr
+			_, _ = fmt.Fprintf(root.ErrOrStderr(), "failed to encode JSON error: %v\n", encodeErr)
+			return err
 		}
 		return err
 	}

--- a/cmd/json_output_test.go
+++ b/cmd/json_output_test.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommandRequestedJSONLastValueWins(t *testing.T) {
+	root := &cobra.Command{Use: "oa"}
+	root.PersistentFlags().Bool("json", false, "json output")
+
+	assert.False(t, commandRequestedJSON(root, []string{"--json", "--json=false"}))
+	assert.True(t, commandRequestedJSON(root, []string{"--json=false", "--json=true"}))
+}
+
+func TestExecuteRootCommandUsesProvidedArgs(t *testing.T) {
+	root := &cobra.Command{Use: "oa"}
+	root.PersistentFlags().Bool("json", false, "json output")
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	root.SetOut(stdout)
+	root.SetErr(stderr)
+
+	ranChild := false
+	root.AddCommand(&cobra.Command{
+		Use: "child",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ranChild = true
+			return errors.New("boom")
+		},
+	})
+
+	err := executeRootCommand(root, []string{"child", "--json"})
+	require.Error(t, err)
+	assert.True(t, ranChild)
+	assert.JSONEq(t, `{"ok":false,"error":"boom"}`, strings.TrimSpace(stderr.String()))
+}

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -67,10 +67,6 @@ func newLoginDeviceCmd(app *app) *cobra.Command {
 }
 
 func runBrowserLogin(cmd *cobra.Command, app *app, accountID domain.AccountID) error {
-	if wantsJSON(cmd) {
-		cmd.Root().SilenceErrors = true
-	}
-
 	pkce, err := authadapter.NewPKCEPair()
 	if err != nil {
 		return writeJSONError(cmd, fmt.Errorf("generate pkce: %w", err))

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -13,6 +13,12 @@ func newLoginCmd(app *app) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "login",
 		Short: "Start account login flows",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if wantsJSON(cmd) {
+				return writeJSONError(cmd, fmt.Errorf("%s: subcommand required", cmd.CommandPath()))
+			}
+			return cmd.Help()
+		},
 	}
 
 	cmd.AddCommand(newLoginBrowserCmd(app), newLoginDeviceCmd(app))
@@ -29,7 +35,7 @@ func newLoginBrowserCmd(app *app) *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			resolvedAccountID, err := resolveAccountID(cmd.Context(), app, accountID)
 			if err != nil {
-				return err
+				return writeJSONError(cmd, err)
 			}
 			return runBrowserLogin(cmd, app, resolvedAccountID)
 		},
@@ -49,9 +55,9 @@ func newLoginDeviceCmd(app *app) *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			resolvedAccountID, err := resolveAccountID(cmd.Context(), app, accountID)
 			if err != nil {
-				return err
+				return writeJSONError(cmd, err)
 			}
-			return fmt.Errorf("%s for account %s: %w", cmd.CommandPath(), resolvedAccountID, errNotImplementedYet)
+			return writeJSONError(cmd, fmt.Errorf("%s for account %s: %w", cmd.CommandPath(), resolvedAccountID, errNotImplementedYet))
 		},
 	}
 
@@ -61,18 +67,22 @@ func newLoginDeviceCmd(app *app) *cobra.Command {
 }
 
 func runBrowserLogin(cmd *cobra.Command, app *app, accountID domain.AccountID) error {
+	if wantsJSON(cmd) {
+		cmd.Root().SilenceErrors = true
+	}
+
 	pkce, err := authadapter.NewPKCEPair()
 	if err != nil {
-		return fmt.Errorf("generate pkce: %w", err)
+		return writeJSONError(cmd, fmt.Errorf("generate pkce: %w", err))
 	}
 	state, err := authadapter.NewState()
 	if err != nil {
-		return fmt.Errorf("generate oauth state: %w", err)
+		return writeJSONError(cmd, fmt.Errorf("generate oauth state: %w", err))
 	}
 
 	server, err := authadapter.StartCallbackServer(app.browserLogin.ListenAddr, state)
 	if err != nil {
-		return fmt.Errorf("start callback server: %w", err)
+		return writeJSONError(cmd, fmt.Errorf("start callback server: %w", err))
 	}
 
 	authURL, err := authadapter.BuildAuthorizationURL(authadapter.AuthorizationRequest{
@@ -85,14 +95,20 @@ func runBrowserLogin(cmd *cobra.Command, app *app, accountID domain.AccountID) e
 	})
 	if err != nil {
 		_ = server.Close()
-		return fmt.Errorf("build authorization url: %w", err)
+		return writeJSONError(cmd, fmt.Errorf("build authorization url: %w", err))
 	}
 
-	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Open this URL to authenticate account %s:\n%s\n", accountID, authURL)
+	if wantsJSON(cmd) {
+		if err := writeCompactJSONOutput(cmd, map[string]any{"event": "authorization_url", "account_id": accountID, "url": authURL}); err != nil {
+			return err
+		}
+	} else {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Open this URL to authenticate account %s:\n%s\n", accountID, authURL)
+	}
 
 	code, err := server.WaitForCode(app.browserLogin.Timeout)
 	if err != nil {
-		return fmt.Errorf("wait for oauth callback: %w", err)
+		return writeJSONError(cmd, fmt.Errorf("wait for oauth callback: %w", err))
 	}
 
 	tokens, err := authadapter.ExchangeCodeForTokens(http.DefaultClient, authadapter.TokenExchangeRequest{
@@ -103,7 +119,7 @@ func runBrowserLogin(cmd *cobra.Command, app *app, accountID domain.AccountID) e
 		CodeVerifier: pkce.Verifier,
 	})
 	if err != nil {
-		return fmt.Errorf("exchange code for tokens: %w", err)
+		return writeJSONError(cmd, fmt.Errorf("exchange code for tokens: %w", err))
 	}
 
 	secretValue, err := encodeOAuthTokens(withCalculatedExpiry(oauthTokens{
@@ -114,12 +130,16 @@ func runBrowserLogin(cmd *cobra.Command, app *app, accountID domain.AccountID) e
 		ExpiresIn:    tokens.ExpiresIn,
 	}, app.now()))
 	if err != nil {
-		return err
+		return writeJSONError(cmd, err)
 	}
 
 	secretKey := fmt.Sprintf("openai://%s/oauth_tokens", accountID)
 	if err := app.service.SetAuth(cmd.Context(), accountID, domain.AuthMethodChatGPT, secretKey, secretValue); err != nil {
-		return fmt.Errorf("save account oauth auth: %w", err)
+		return writeJSONError(cmd, fmt.Errorf("save account oauth auth: %w", err))
+	}
+
+	if wantsJSON(cmd) {
+		return writeCompactJSONOutput(cmd, map[string]any{"event": "authenticated", "account_id": accountID})
 	}
 
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Authenticated account %s\n", accountID)

--- a/cmd/noctalia.go
+++ b/cmd/noctalia.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/bnema/openai-accounts-cli/internal/application"
@@ -212,8 +213,8 @@ func buildNoctaliaAccounts(statuses []application.Status, recommendation applica
 				Selected: selected[status.Account.ID],
 				Eligible: domain.AccountUsableForSelection(status.Account, now),
 			},
-			Daily:        buildNoctaliaLimit(status.DailyLimit),
-			Weekly:       buildNoctaliaLimit(status.WeeklyLimit),
+			Daily:        buildNoctaliaLimit(status.Account.ID, "daily", status.DailyLimit),
+			Weekly:       buildNoctaliaLimit(status.Account.ID, "weekly", status.WeeklyLimit),
 			Subscription: buildNoctaliaSubscription(status.Subscription),
 		}
 		accounts = append(accounts, account)
@@ -222,9 +223,13 @@ func buildNoctaliaAccounts(statuses []application.Status, recommendation applica
 	return accounts
 }
 
-func buildNoctaliaLimit(limit *application.StatusLimit) *noctaliaLimit {
+func buildNoctaliaLimit(accountID domain.AccountID, window string, limit *application.StatusLimit) *noctaliaLimit {
 	if limit == nil {
 		return nil
+	}
+
+	if limit.Percent < 0 || limit.Percent > 100 {
+		log.Printf("warning: noctalia snapshot %s limit percent out of range for account %s: %.2f", window, accountID, limit.Percent)
 	}
 
 	remaining := 100 - limit.Percent

--- a/cmd/noctalia.go
+++ b/cmd/noctalia.go
@@ -1,0 +1,275 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/bnema/openai-accounts-cli/internal/application"
+	"github.com/bnema/openai-accounts-cli/internal/domain"
+	"github.com/spf13/cobra"
+)
+
+const noctaliaSnapshotSchemaVersion = 1
+
+type noctaliaSnapshotOutput struct {
+	SchemaVersion  int                       `json:"schema_version"`
+	GeneratedAt    time.Time                 `json:"generated_at"`
+	Refreshed      bool                      `json:"refreshed"`
+	RefreshCommand []string                  `json:"refresh_command"`
+	Recommendation noctaliaRecommendation    `json:"recommendation"`
+	Accounts       []noctaliaAccount         `json:"accounts"`
+	SyncTargets    []noctaliaSyncTarget      `json:"sync_targets"`
+	Warnings       []noctaliaSnapshotWarning `json:"warnings,omitempty"`
+}
+
+type noctaliaRecommendation struct {
+	Available   bool   `json:"available"`
+	AccountID   string `json:"account_id,omitempty"`
+	AccountName string `json:"account_name,omitempty"`
+	Rank        int    `json:"rank,omitempty"`
+	Reason      string `json:"reason,omitempty"`
+	Message     string `json:"message,omitempty"`
+}
+
+type noctaliaAccount struct {
+	ID             string                        `json:"id"`
+	Name           string                        `json:"name"`
+	Provider       string                        `json:"provider,omitempty"`
+	Model          string                        `json:"model,omitempty"`
+	PlanType       string                        `json:"plan_type,omitempty"`
+	AuthMethod     string                        `json:"auth_method,omitempty"`
+	AuthConfigured bool                          `json:"auth_configured"`
+	Recommendation noctaliaAccountRecommendation `json:"recommendation"`
+	Daily          *noctaliaLimit                `json:"daily,omitempty"`
+	Weekly         *noctaliaLimit                `json:"weekly,omitempty"`
+	Subscription   *noctaliaSubscription         `json:"subscription,omitempty"`
+}
+
+type noctaliaAccountRecommendation struct {
+	Rank     int  `json:"rank,omitempty"`
+	Selected bool `json:"selected"`
+	Eligible bool `json:"eligible"`
+}
+
+type noctaliaLimit struct {
+	PercentUsed      float64   `json:"percent_used"`
+	PercentRemaining float64   `json:"percent_remaining"`
+	ResetsAt         time.Time `json:"resets_at,omitempty"`
+	CapturedAt       time.Time `json:"captured_at,omitempty"`
+}
+
+type noctaliaSubscription struct {
+	ActiveStart     time.Time `json:"active_start,omitempty"`
+	ActiveUntil     time.Time `json:"active_until,omitempty"`
+	WillRenew       bool      `json:"will_renew"`
+	BillingPeriod   string    `json:"billing_period,omitempty"`
+	BillingCurrency string    `json:"billing_currency,omitempty"`
+	IsDelinquent    bool      `json:"is_delinquent"`
+	CapturedAt      time.Time `json:"captured_at,omitempty"`
+}
+
+type noctaliaSyncTarget struct {
+	ID      string   `json:"id"`
+	Label   string   `json:"label"`
+	Command []string `json:"command"`
+}
+
+type noctaliaSnapshotWarning struct {
+	AccountID string `json:"account_id"`
+	Message   string `json:"message"`
+}
+
+func newNoctaliaCmd(app *app) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "noctalia",
+		Short: "Machine-friendly endpoints for the Noctalia plugin",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if wantsJSON(cmd) {
+				return writeJSONError(cmd, fmt.Errorf("%s: subcommand required", cmd.CommandPath()))
+			}
+			return cmd.Help()
+		},
+	}
+
+	cmd.AddCommand(newNoctaliaSnapshotCmd(app))
+
+	return cmd
+}
+
+func newNoctaliaSnapshotCmd(app *app) *cobra.Command {
+	var refresh bool
+
+	cmd := &cobra.Command{
+		Use:   "snapshot",
+		Short: "Return a stable snapshot for the Noctalia plugin",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if !wantsJSON(cmd) {
+				return writeJSONError(cmd, fmt.Errorf("%s: --json is required", cmd.CommandPath()))
+			}
+
+			payload, err := buildNoctaliaSnapshot(cmd, app, refresh)
+			if err != nil {
+				return writeJSONError(cmd, err)
+			}
+			return writeJSONOutput(cmd, payload)
+		},
+	}
+
+	cmd.Flags().BoolVar(&refresh, "refresh", false, "Refresh usage data before building the snapshot")
+
+	return cmd
+}
+
+func buildNoctaliaSnapshot(cmd *cobra.Command, app *app, refresh bool) (noctaliaSnapshotOutput, error) {
+	statuses, err := loadStatuses(cmd, app.service, "")
+	if err != nil {
+		return noctaliaSnapshotOutput{}, err
+	}
+
+	summary := fetchSummary{}
+	if refresh {
+		summary, err = refreshNoctaliaStatuses(cmd.Context(), app, statuses)
+		if err != nil {
+			return noctaliaSnapshotOutput{}, err
+		}
+
+		statuses, err = loadStatuses(cmd, app.service, "")
+		if err != nil {
+			return noctaliaSnapshotOutput{}, err
+		}
+	}
+
+	now := app.now()
+	recommendation := application.RecommendAccountsFromStatuses(statuses, now)
+
+	payload := noctaliaSnapshotOutput{
+		SchemaVersion:  noctaliaSnapshotSchemaVersion,
+		GeneratedAt:    now,
+		Refreshed:      refresh,
+		RefreshCommand: []string{"noctalia", "snapshot", "--json", "--refresh"},
+		Recommendation: buildNoctaliaRecommendation(recommendation),
+		Accounts:       buildNoctaliaAccounts(statuses, recommendation, now),
+		SyncTargets: []noctaliaSyncTarget{
+			{ID: "opencode", Label: "OpenCode", Command: []string{"sync", "opencode", "--json"}},
+			{ID: "codex", Label: "Codex", Command: []string{"sync", "codex", "--json"}},
+			{ID: "pi", Label: "Pi", Command: []string{"sync", "pi", "--json"}},
+			{ID: "all", Label: "All", Command: []string{"sync", "--all", "--json"}},
+		},
+		Warnings: buildNoctaliaWarnings(summary),
+	}
+
+	return payload, nil
+}
+
+func refreshNoctaliaStatuses(ctx context.Context, app *app, statuses []application.Status) (fetchSummary, error) {
+	accounts := filterChatGPTAccounts(statuses)
+	if len(accounts) == 0 {
+		return fetchSummary{}, nil
+	}
+
+	return fetchAccountsConcurrently(ctx, app, accounts)
+}
+
+func buildNoctaliaRecommendation(recommendation application.RecommendationResult) noctaliaRecommendation {
+	output := noctaliaRecommendation{}
+	if recommendation.Selected != nil {
+		output.Available = true
+		output.AccountID = string(recommendation.Selected.Status.Account.ID)
+		output.AccountName = recommendation.Selected.Status.Account.Name
+		output.Rank = recommendation.Selected.Rank
+		output.Message = fmt.Sprintf("recommended account: %s", recommendation.Selected.Status.Account.Name)
+		return output
+	}
+
+	output.Reason = string(recommendation.UnavailableReason)
+	output.Message = recommendation.UnavailableMessage
+	return output
+}
+
+func buildNoctaliaAccounts(statuses []application.Status, recommendation application.RecommendationResult, now time.Time) []noctaliaAccount {
+	ranks := make(map[domain.AccountID]int, len(recommendation.Ordered))
+	selected := make(map[domain.AccountID]bool, len(recommendation.Ordered))
+	for _, candidate := range recommendation.Ordered {
+		ranks[candidate.Status.Account.ID] = candidate.Rank
+	}
+	if recommendation.Selected != nil {
+		selected[recommendation.Selected.Status.Account.ID] = true
+	}
+
+	accounts := make([]noctaliaAccount, 0, len(statuses))
+	for _, status := range statuses {
+		account := noctaliaAccount{
+			ID:             string(status.Account.ID),
+			Name:           status.Account.Name,
+			Provider:       status.Account.Metadata.Provider,
+			Model:          status.Account.Metadata.Model,
+			PlanType:       status.Account.Metadata.PlanType,
+			AuthMethod:     string(status.Account.Auth.Method),
+			AuthConfigured: status.Account.Auth.Method != "" && status.Account.Auth.SecretRef != "",
+			Recommendation: noctaliaAccountRecommendation{
+				Rank:     ranks[status.Account.ID],
+				Selected: selected[status.Account.ID],
+				Eligible: domain.AccountUsableForSelection(status.Account, now),
+			},
+			Daily:        buildNoctaliaLimit(status.DailyLimit),
+			Weekly:       buildNoctaliaLimit(status.WeeklyLimit),
+			Subscription: buildNoctaliaSubscription(status.Subscription),
+		}
+		accounts = append(accounts, account)
+	}
+
+	return accounts
+}
+
+func buildNoctaliaLimit(limit *application.StatusLimit) *noctaliaLimit {
+	if limit == nil {
+		return nil
+	}
+
+	remaining := 100 - limit.Percent
+	if remaining < 0 {
+		remaining = 0
+	}
+	if remaining > 100 {
+		remaining = 100
+	}
+
+	return &noctaliaLimit{
+		PercentUsed:      limit.Percent,
+		PercentRemaining: remaining,
+		ResetsAt:         limit.ResetsAt,
+		CapturedAt:       limit.CapturedAt,
+	}
+}
+
+func buildNoctaliaSubscription(sub *application.StatusSubscription) *noctaliaSubscription {
+	if sub == nil {
+		return nil
+	}
+
+	return &noctaliaSubscription{
+		ActiveStart:     sub.ActiveStart,
+		ActiveUntil:     sub.ActiveUntil,
+		WillRenew:       sub.WillRenew,
+		BillingPeriod:   sub.BillingPeriod,
+		BillingCurrency: sub.BillingCurrency,
+		IsDelinquent:    sub.IsDelinquent,
+		CapturedAt:      sub.CapturedAt,
+	}
+}
+
+func buildNoctaliaWarnings(summary fetchSummary) []noctaliaSnapshotWarning {
+	if !summary.hasFailures() {
+		return nil
+	}
+
+	warnings := make([]noctaliaSnapshotWarning, 0, len(summary.failures))
+	for _, failure := range summary.failures {
+		warnings = append(warnings, noctaliaSnapshotWarning{
+			AccountID: string(failure.accountID),
+			Message:   failure.err.Error(),
+		})
+	}
+	return warnings
+}

--- a/cmd/opencode.go
+++ b/cmd/opencode.go
@@ -1,11 +1,21 @@
 package cmd
 
-import "github.com/spf13/cobra"
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
 
 func newOpencodeCmd(app *app) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "opencode",
 		Short: "Manage OpenCode integration",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if wantsJSON(cmd) {
+				return writeJSONError(cmd, fmt.Errorf("%s: subcommand required", cmd.CommandPath()))
+			}
+			return cmd.Help()
+		},
 	}
 
 	cmd.AddCommand(

--- a/cmd/opencode_doctor.go
+++ b/cmd/opencode_doctor.go
@@ -10,9 +10,9 @@ import (
 )
 
 type doctorCheck struct {
-	Name   string
-	Status string
-	Detail string
+	Name   string `json:"name"`
+	Status string `json:"status"`
+	Detail string `json:"detail"`
 }
 
 func newOpencodeDoctorCmd(app *app) *cobra.Command {
@@ -22,7 +22,11 @@ func newOpencodeDoctorCmd(app *app) *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			checks, err := runOpencodeDoctor(cmd.Context(), app)
 			if err != nil {
-				return err
+				return writeJSONError(cmd, err)
+			}
+
+			if wantsJSON(cmd) {
+				return writeJSONOutput(cmd, map[string]any{"checks": checks})
 			}
 
 			for _, check := range checks {

--- a/cmd/opencode_handler.go
+++ b/cmd/opencode_handler.go
@@ -30,6 +30,9 @@ func newHandleCmd(app *app) *cobra.Command {
 		Use:   "handle",
 		Short: "Handle local tool integration callbacks",
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if wantsJSON(cmd) {
+				return writeJSONError(cmd, fmt.Errorf("%s: subcommand required", cmd.CommandPath()))
+			}
 			return cmd.Help()
 		},
 	}
@@ -39,14 +42,12 @@ func newHandleCmd(app *app) *cobra.Command {
 }
 
 func newOpencodeHandleCmd(app *app) *cobra.Command {
-	var jsonOutput bool
-
-	cmd := &cobra.Command{
+	return &cobra.Command{
 		Use:   "opencode",
 		Short: "Handle OpenCode requests",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			if !jsonOutput {
-				return fmt.Errorf("%s: --json is required", cmd.CommandPath())
+			if !wantsJSON(cmd) {
+				return writeJSONError(cmd, fmt.Errorf("%s: --json is required", cmd.CommandPath()))
 			}
 
 			var request opencodeFailureRequest
@@ -62,9 +63,6 @@ func newOpencodeHandleCmd(app *app) *cobra.Command {
 			return writeOpencodeDecisionResponse(cmd, response)
 		},
 	}
-
-	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output JSON")
-	return cmd
 }
 
 func handleOpencodeFailure(cmd *cobra.Command, app *app, request opencodeFailureRequest) (opencodeDecisionResponse, error) {

--- a/cmd/opencode_install.go
+++ b/cmd/opencode_install.go
@@ -18,6 +18,9 @@ func newInstallCmd(app *app) *cobra.Command {
 		Use:   "install",
 		Short: "Install local tool integrations",
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if wantsJSON(cmd) {
+				return writeJSONError(cmd, fmt.Errorf("%s: subcommand required", cmd.CommandPath()))
+			}
 			return cmd.Help()
 		},
 	}
@@ -36,13 +39,17 @@ func newPIInstallCmd(_ *app) *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			path, err := piExtensionPath()
 			if err != nil {
-				return err
+				return writeJSONError(cmd, err)
 			}
 			if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
-				return fmt.Errorf("create pi extension directory: %w", err)
+				return writeJSONError(cmd, fmt.Errorf("create pi extension directory: %w", err))
 			}
 			if err := os.WriteFile(path, []byte(piAuthHotReloadExtension), 0o600); err != nil {
-				return fmt.Errorf("write pi auth hot-reload extension: %w", err)
+				return writeJSONError(cmd, fmt.Errorf("write pi auth hot-reload extension: %w", err))
+			}
+
+			if wantsJSON(cmd) {
+				return writeJSONOutput(cmd, map[string]any{"ok": true, "path": path, "reload_command": "/reload"})
 			}
 
 			_, err = fmt.Fprintf(cmd.OutOrStdout(), "installed Pi extension to %s\nreload active Pi sessions with /reload\n", path)
@@ -58,25 +65,30 @@ func newOpencodeInstallCmd(_ *app) *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			configDir, err := opencodeConfigDir()
 			if err != nil {
-				return err
+				return writeJSONError(cmd, err)
 			}
 			path, err := opencodePluginPath()
 			if err != nil {
-				return err
+				return writeJSONError(cmd, err)
 			}
 
 			if err := os.MkdirAll(configDir, 0o700); err != nil {
-				return fmt.Errorf("create opencode config directory: %w", err)
+				return writeJSONError(cmd, fmt.Errorf("create opencode config directory: %w", err))
 			}
 			if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
-				return fmt.Errorf("create opencode plugin directory: %w", err)
+				return writeJSONError(cmd, fmt.Errorf("create opencode plugin directory: %w", err))
 			}
-			if err := writeOpencodePluginPackage(filepath.Join(configDir, "package.json")); err != nil {
-				return err
+			packagePath := filepath.Join(configDir, "package.json")
+			if err := writeOpencodePluginPackage(packagePath); err != nil {
+				return writeJSONError(cmd, err)
 			}
 
 			if err := os.WriteFile(path, []byte(opencodeShim), 0o600); err != nil {
-				return fmt.Errorf("write opencode plugin shim: %w", err)
+				return writeJSONError(cmd, fmt.Errorf("write opencode plugin shim: %w", err))
+			}
+
+			if wantsJSON(cmd) {
+				return writeJSONOutput(cmd, map[string]any{"ok": true, "path": path, "config_path": packagePath})
 			}
 
 			_, err = fmt.Fprintf(cmd.OutOrStdout(), "installed OpenCode plugin to %s\n", path)

--- a/cmd/opencode_sync.go
+++ b/cmd/opencode_sync.go
@@ -1,13 +1,17 @@
 package cmd
 
-import "github.com/spf13/cobra"
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
 
 func newSyncOpencodeCmd(app *app, flags *syncFlags) *cobra.Command {
 	return &cobra.Command{
 		Use:   "opencode",
 		Short: "Sync OpenCode auth",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return syncSingleTarget(cmd, app, flags.options(), "OpenCode", writeOAuthTokensToOpencode)
+			return writeJSONError(cmd, syncSingleTarget(cmd, app, flags.options(), "opencode", "OpenCode", writeOAuthTokensToOpencode))
 		},
 	}
 }
@@ -17,7 +21,13 @@ func newOpencodeSyncCmd(app *app) *cobra.Command {
 	cmd := newSyncOpencodeCmd(app, &flags)
 	cmd.Use = "sync"
 	cmd.Hidden = true
-	cmd.Deprecated = "use `oa sync opencode` instead"
+	cmd.PreRunE = func(cmd *cobra.Command, _ []string) error {
+		if wantsJSON(cmd) {
+			return nil
+		}
+		_, err := fmt.Fprintln(cmd.ErrOrStderr(), `Command "sync" is deprecated, use `+"`oa sync opencode`"+` instead`)
+		return err
+	}
 	cmd.Flags().BoolVar(&flags.evenly, "evenly", false, "rebalance among top candidates using recent selection history")
 	cmd.Flags().StringVar(&flags.forceAccountID, "force-account-id", "", "sync with this account ID instead of the best ranked account")
 	return cmd

--- a/cmd/opencode_systemd.go
+++ b/cmd/opencode_systemd.go
@@ -16,24 +16,28 @@ func newOpencodeInstallSystemdCmd(_ *app) *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			unitDir, err := opencodeSystemdUnitDir()
 			if err != nil {
-				return err
+				return writeJSONError(cmd, err)
 			}
 			if err := os.MkdirAll(unitDir, 0o700); err != nil {
-				return fmt.Errorf("create systemd user unit directory: %w", err)
+				return writeJSONError(cmd, fmt.Errorf("create systemd user unit directory: %w", err))
 			}
 
 			execPath, err := os.Executable()
 			if err != nil {
-				return fmt.Errorf("resolve executable path: %w", err)
+				return writeJSONError(cmd, fmt.Errorf("resolve executable path: %w", err))
 			}
 
 			servicePath := filepath.Join(unitDir, opencodeServiceName)
 			timerPath := filepath.Join(unitDir, opencodeTimerName)
 			if err := os.WriteFile(servicePath, []byte(renderOpencodeSystemdService(execPath)), 0o600); err != nil {
-				return fmt.Errorf("write systemd service unit: %w", err)
+				return writeJSONError(cmd, fmt.Errorf("write systemd service unit: %w", err))
 			}
 			if err := os.WriteFile(timerPath, []byte(renderOpencodeSystemdTimer()), 0o600); err != nil {
-				return fmt.Errorf("write systemd timer unit: %w", err)
+				return writeJSONError(cmd, fmt.Errorf("write systemd timer unit: %w", err))
+			}
+
+			if wantsJSON(cmd) {
+				return writeJSONOutput(cmd, map[string]any{"ok": true, "unit_dir": unitDir, "service_path": servicePath, "timer_path": timerPath, "timer": opencodeTimerName})
 			}
 
 			_, err = fmt.Fprintf(cmd.OutOrStdout(), "installed %s and %s in %s\nrun: systemctl --user daemon-reload && systemctl --user enable --now %s\n", opencodeServiceName, opencodeTimerName, unitDir, opencodeTimerName)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,19 +1,34 @@
 package cmd
 
-import "github.com/spf13/cobra"
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
 
 func Execute() error {
-	return newRootCmd().Execute()
+	return executeRootCommand(newRootCmd(), os.Args[1:])
 }
 
 func newBaseRootCmd() *cobra.Command {
-	return &cobra.Command{
+	rootCmd := &cobra.Command{
 		Use:           "oa",
 		Short:         "OpenAI Accounts CLI (oa): manage auth and usage limits",
 		Long:          "oa (OpenAI Accounts CLI) helps you store account auth references, run OpenAI login flows, fetch usage/limit snapshots, and view account status from the terminal.",
 		SilenceUsage:  true,
 		SilenceErrors: false,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if wantsJSON(cmd) {
+				return writeJSONError(cmd, fmt.Errorf("%s: subcommand required", cmd.CommandPath()))
+			}
+			return cmd.Help()
+		},
 	}
+
+	rootCmd.PersistentFlags().Bool("json", false, "Render JSON output")
+
+	return rootCmd
 }
 
 func newRootCmd() *cobra.Command {
@@ -21,8 +36,8 @@ func newRootCmd() *cobra.Command {
 	if err != nil {
 		rootCmd := newBaseRootCmd()
 
-		rootCmd.RunE = func(_ *cobra.Command, _ []string) error {
-			return err
+		rootCmd.RunE = func(cmd *cobra.Command, _ []string) error {
+			return writeJSONError(cmd, err)
 		}
 		return rootCmd
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -56,6 +56,7 @@ func newRootCmdWithApp(app *app) *cobra.Command {
 		newSyncCmd(app),
 		newInstallCmd(app),
 		newHandleCmd(app),
+		newNoctaliaCmd(app),
 		newOpencodeCmd(app),
 	)
 

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -192,7 +192,12 @@ func refreshSyncUsageCaches(cmd *cobra.Command, app *app) (fetchSummary, error) 
 
 	summary, err := fetchAccountsConcurrently(cmd.Context(), app, filterChatGPTAccounts(statuses))
 	if !wantsJSON(cmd) {
-		writeFetchSummaryPlain(cmd.ErrOrStderr(), summary)
+		if writeErr := writeFetchSummaryPlain(cmd.ErrOrStderr(), summary); writeErr != nil {
+			if err != nil {
+				return summary, errors.Join(err, fmt.Errorf("write fetch summary: %w", writeErr))
+			}
+			return summary, fmt.Errorf("write fetch summary: %w", writeErr)
+		}
 	}
 
 	return summary, err

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -14,6 +14,7 @@ import (
 type syncTokenWriter func(app *app, tokens oauthTokens) error
 
 type syncTargetTokenWriter struct {
+	id    string
 	name  string
 	write syncTokenWriter
 }
@@ -44,9 +45,15 @@ func newSyncCmd(app *app) *cobra.Command {
 		Short: "Sync ChatGPT OAuth auth into local tools",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if !all {
+				if wantsJSON(cmd) {
+					return writeJSONError(cmd, fmt.Errorf("%s: --all or a target subcommand is required", cmd.CommandPath()))
+				}
 				return cmd.Help()
 			}
-			return syncAllTargets(cmd, app, flags.options())
+			if err := syncAllTargets(cmd, app, flags.options()); err != nil {
+				return writeJSONError(cmd, err)
+			}
+			return nil
 		},
 	}
 
@@ -68,7 +75,7 @@ func newSyncCodexCmd(app *app, flags *syncFlags) *cobra.Command {
 		Use:   "codex",
 		Short: "Sync Codex auth",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return syncSingleTarget(cmd, app, flags.options(), "Codex", writeOAuthTokensToCodex)
+			return writeJSONError(cmd, syncSingleTarget(cmd, app, flags.options(), "codex", "Codex", writeOAuthTokensToCodex))
 		},
 	}
 }
@@ -79,13 +86,13 @@ func newSyncPICmd(app *app, flags *syncFlags) *cobra.Command {
 		Aliases: []string{"pi-mono"},
 		Short:   "Sync Pi auth",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return syncSingleTarget(cmd, app, flags.options(), "Pi", writeOAuthTokensToPI)
+			return writeJSONError(cmd, syncSingleTarget(cmd, app, flags.options(), "pi", "Pi", writeOAuthTokensToPI))
 		},
 	}
 }
 
-func syncSingleTarget(cmd *cobra.Command, app *app, options syncOptions, targetName string, writer syncTokenWriter) error {
-	tokens, status, err := loadTokensForSync(cmd, app, options)
+func syncSingleTarget(cmd *cobra.Command, app *app, options syncOptions, targetID, targetName string, writer syncTokenWriter) error {
+	tokens, status, summary, err := loadTokensForSync(cmd, app, options)
 	if err != nil {
 		return err
 	}
@@ -98,21 +105,36 @@ func syncSingleTarget(cmd *cobra.Command, app *app, options syncOptions, targetN
 		}
 	}
 
+	if wantsJSON(cmd) {
+		payload := map[string]any{
+			"ok":           true,
+			"target":       targetID,
+			"account_id":   status.Account.ID,
+			"account_name": status.Account.Name,
+		}
+		if summary.hasFailures() {
+			payload["warnings"] = summary.failurePayload()
+		}
+		return writeJSONOutput(cmd, payload)
+	}
+
 	_, err = fmt.Fprintf(cmd.OutOrStdout(), "synced %s auth for %s (%s)\n", targetName, status.Account.Name, status.Account.ID)
 	return err
 }
 
-func loadTokensForSync(cmd *cobra.Command, app *app, options syncOptions) (oauthTokens, application.Status, error) {
+func loadTokensForSync(cmd *cobra.Command, app *app, options syncOptions) (oauthTokens, application.Status, fetchSummary, error) {
 	if options.forceAccountID != "" {
-		return loadOAuthTokensForAccount(cmd.Context(), app, options.forceAccountID)
+		tokens, status, err := loadOAuthTokensForAccount(cmd.Context(), app, options.forceAccountID)
+		return tokens, status, fetchSummary{}, err
 	}
 
-	ranked, err := freshRankedSyncAccounts(cmd, app, options.evenly)
+	ranked, summary, err := freshRankedSyncAccounts(cmd, app, options.evenly)
 	if err != nil {
-		return oauthTokens{}, application.Status{}, err
+		return oauthTokens{}, application.Status{}, summary, err
 	}
 
-	return loadTokensForAvailableAccount(cmd, app, ranked)
+	tokens, status, err := loadTokensForAvailableAccount(cmd, app, ranked)
+	return tokens, status, summary, err
 }
 
 func loadTokensForAvailableAccount(cmd *cobra.Command, app *app, ranked []application.Status) (oauthTokens, application.Status, error) {
@@ -142,36 +164,42 @@ func noUsableSyncAccountError(syncErr error) error {
 	return fmt.Errorf("%w: %s", application.ErrNoEligibleSyncAccount, syncErr.Error())
 }
 
-func freshRankedSyncAccounts(cmd *cobra.Command, app *app, evenly bool) ([]application.Status, error) {
-	if err := refreshSyncUsageCaches(cmd, app); err != nil {
-		return nil, err
+func freshRankedSyncAccounts(cmd *cobra.Command, app *app, evenly bool) ([]application.Status, fetchSummary, error) {
+	summary, err := refreshSyncUsageCaches(cmd, app)
+	if err != nil {
+		return nil, summary, err
 	}
 
 	ranked, err := app.service.RankSyncAccounts(cmd.Context())
 	if err != nil {
-		return nil, err
+		return nil, summary, err
 	}
 	if evenly {
 		ranked, err = app.service.RebalanceStatusesEvenly(cmd.Context(), ranked)
 		if err != nil {
-			return nil, err
+			return nil, summary, err
 		}
 	}
 
-	return ranked, nil
+	return ranked, summary, nil
 }
 
-func refreshSyncUsageCaches(cmd *cobra.Command, app *app) error {
+func refreshSyncUsageCaches(cmd *cobra.Command, app *app) (fetchSummary, error) {
 	statuses, err := app.service.GetStatusAll(cmd.Context())
 	if err != nil {
-		return err
+		return fetchSummary{}, err
 	}
 
-	return fetchAccountsConcurrently(cmd.Context(), app, filterChatGPTAccounts(statuses), cmd.ErrOrStderr())
+	summary, err := fetchAccountsConcurrently(cmd.Context(), app, filterChatGPTAccounts(statuses))
+	if !wantsJSON(cmd) {
+		writeFetchSummaryPlain(cmd.ErrOrStderr(), summary)
+	}
+
+	return summary, err
 }
 
 func syncAllTargets(cmd *cobra.Command, app *app, options syncOptions) error {
-	tokens, status, err := loadTokensForSync(cmd, app, options)
+	tokens, status, summary, err := loadTokensForSync(cmd, app, options)
 	if err != nil {
 		return err
 	}
@@ -187,30 +215,49 @@ func syncAllTargets(cmd *cobra.Command, app *app, options syncOptions) error {
 		}
 	}
 
-	for _, targetName := range syncedTargets {
-		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "synced %s auth for %s (%s)\n", targetName, status.Account.Name, status.Account.ID); err != nil {
+	if wantsJSON(cmd) {
+		targets := make([]string, 0, len(syncedTargets))
+		for _, target := range syncedTargets {
+			targets = append(targets, target.id)
+		}
+		payload := map[string]any{
+			"ok":           true,
+			"targets":      targets,
+			"account_id":   status.Account.ID,
+			"account_name": status.Account.Name,
+		}
+		if summary.hasFailures() {
+			payload["warnings"] = summary.failurePayload()
+		}
+		return writeJSONOutput(cmd, payload)
+	}
+
+	for _, target := range syncedTargets {
+		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "synced %s auth for %s (%s)\n", target.name, status.Account.Name, status.Account.ID); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func writeOAuthTokensToAllTargets(app *app, tokens oauthTokens) ([]string, error) {
+func writeOAuthTokensToAllTargets(app *app, tokens oauthTokens) ([]syncTargetTokenWriter, error) {
 	targets := []syncTargetTokenWriter{
-		{name: "OpenCode", write: writeOAuthTokensToOpencode},
-		{name: "Codex", write: writeOAuthTokensToCodex},
-		{name: "Pi", write: writeOAuthTokensToPI},
+		{id: "opencode", name: "OpenCode", write: writeOAuthTokensToOpencode},
+		{id: "codex", name: "Codex", write: writeOAuthTokensToCodex},
+		{id: "pi", name: "Pi", write: writeOAuthTokensToPI},
 	}
 
-	synced := make([]string, 0, len(targets))
+	synced := make([]syncTargetTokenWriter, 0, len(targets))
+	syncedNames := make([]string, 0, len(targets))
 	for _, target := range targets {
 		if err := target.write(app, tokens); err != nil {
 			if len(synced) > 0 {
-				return synced, fmt.Errorf("partial sync failure: synced %s; %s failed: %w", strings.Join(synced, ", "), target.name, err)
+				return synced, fmt.Errorf("partial sync failure: synced %s; %s failed: %w", strings.Join(syncedNames, ", "), target.name, err)
 			}
 			return synced, fmt.Errorf("%s failed: %w", target.name, err)
 		}
-		synced = append(synced, target.name)
+		synced = append(synced, target)
+		syncedNames = append(syncedNames, target.name)
 	}
 
 	return synced, nil

--- a/cmd/usage.go
+++ b/cmd/usage.go
@@ -132,7 +132,12 @@ func runUsageFetch(cmd *cobra.Command, app *app, accountID string, asJSON bool) 
 		result, err := fetchAccountsConcurrently(ctx, app, chatgptAccounts)
 		summary = result
 		if !asJSON {
-			writeFetchSummaryPlain(cmd.ErrOrStderr(), result)
+			if writeErr := writeFetchSummaryPlain(cmd.ErrOrStderr(), result); writeErr != nil {
+				if err != nil {
+					return errors.Join(err, fmt.Errorf("write fetch summary: %w", writeErr))
+				}
+				return fmt.Errorf("write fetch summary: %w", writeErr)
+			}
 		}
 		return err
 	}
@@ -222,6 +227,10 @@ func fetchAccountsConcurrently(ctx context.Context, app *app, accounts []domain.
 		}
 	}
 
+	if len(accounts) == 0 {
+		return summary, nil
+	}
+
 	if len(summary.failures) == len(accounts) {
 		if len(accounts) == 1 {
 			return summary, summary.failures[0].err
@@ -232,19 +241,27 @@ func fetchAccountsConcurrently(ctx context.Context, app *app, accounts []domain.
 	return summary, nil
 }
 
-func writeFetchSummaryPlain(errWriter io.Writer, summary fetchSummary) {
+func writeFetchSummaryPlain(errWriter io.Writer, summary fetchSummary) error {
 	if errWriter == nil || !summary.hasFailures() {
-		return
+		return nil
 	}
 
-	fmt.Fprintln(errWriter, "\nFailed to fetch:")
+	if _, err := fmt.Fprintln(errWriter, "\nFailed to fetch:"); err != nil {
+		return err
+	}
 	for _, failure := range summary.failures {
-		fmt.Fprintf(errWriter, "  - %v\n", failure.err)
+		if _, err := fmt.Fprintf(errWriter, "  - %v\n", failure.err); err != nil {
+			return err
+		}
 	}
 
 	if len(summary.successes) > 0 {
-		fmt.Fprintf(errWriter, "\n%d/%d accounts updated successfully\n", len(summary.successes), len(summary.successes)+len(summary.failures))
+		if _, err := fmt.Fprintf(errWriter, "\n%d/%d accounts updated successfully\n", len(summary.successes), len(summary.successes)+len(summary.failures)); err != nil {
+			return err
+		}
 	}
+
+	return nil
 }
 
 func fetchAndPersistLimits(ctx context.Context, app *app, account domain.Account) error {

--- a/cmd/usage.go
+++ b/cmd/usage.go
@@ -23,7 +23,6 @@ var refreshLocks sync.Map
 
 func newUsageCmd(app *app) *cobra.Command {
 	var accountID string
-	var asJSON bool
 
 	cmd := &cobra.Command{
 		Use:     "usage",
@@ -31,12 +30,14 @@ func newUsageCmd(app *app) *cobra.Command {
 		Short:   "Fetch and display account usage limits",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runUsageFetch(cmd, app, accountID, asJSON)
+			if err := runUsageFetch(cmd, app, accountID, wantsJSON(cmd)); err != nil {
+				return writeJSONError(cmd, err)
+			}
+			return nil
 		},
 	}
 
 	cmd.Flags().StringVar(&accountID, "account", "", "Account ID (default: all accounts)")
-	cmd.Flags().BoolVar(&asJSON, "json", false, "Render JSON output")
 
 	return cmd
 }
@@ -85,6 +86,34 @@ type fetchResult struct {
 	err       error
 }
 
+type fetchSummary struct {
+	successes []domain.AccountID
+	failures  []fetchResult
+}
+
+func (s fetchSummary) hasFailures() bool {
+	return len(s.failures) > 0
+}
+
+func (s fetchSummary) failurePayload() []map[string]string {
+	payload := make([]map[string]string, 0, len(s.failures))
+	for _, failure := range s.failures {
+		payload = append(payload, map[string]string{
+			"account_id": string(failure.accountID),
+			"error":      failure.err.Error(),
+		})
+	}
+	return payload
+}
+
+func (s fetchSummary) errorByAccountID() map[domain.AccountID]string {
+	out := make(map[domain.AccountID]string, len(s.failures))
+	for _, failure := range s.failures {
+		out[failure.accountID] = failure.err.Error()
+	}
+	return out
+}
+
 func runUsageFetch(cmd *cobra.Command, app *app, accountID string, asJSON bool) error {
 	statuses, err := loadStatuses(cmd, app.service, accountID)
 	if err != nil {
@@ -93,11 +122,19 @@ func runUsageFetch(cmd *cobra.Command, app *app, accountID string, asJSON bool) 
 
 	chatgptAccounts := filterChatGPTAccounts(statuses)
 
+	var summary fetchSummary
 	fetchCmd := func(ctx context.Context) error {
 		if len(chatgptAccounts) == 0 {
+			summary = fetchSummary{}
 			return nil
 		}
-		return fetchAccountsConcurrently(ctx, app, chatgptAccounts, cmd.ErrOrStderr())
+
+		result, err := fetchAccountsConcurrently(ctx, app, chatgptAccounts)
+		summary = result
+		if !asJSON {
+			writeFetchSummaryPlain(cmd.ErrOrStderr(), result)
+		}
+		return err
 	}
 
 	if asJSON {
@@ -113,6 +150,12 @@ func runUsageFetch(cmd *cobra.Command, app *app, accountID string, asJSON bool) 
 	updated, err := loadStatuses(cmd, app.service, accountID)
 	if err != nil {
 		return err
+	}
+
+	if asJSON && summary.hasFailures() {
+		if err := json.NewEncoder(cmd.ErrOrStderr()).Encode(map[string]any{"warnings": summary.failurePayload()}); err != nil {
+			return err
+		}
 	}
 
 	recommendation := application.RecommendationResult{}
@@ -136,7 +179,7 @@ func filterChatGPTAccounts(statuses []application.Status) []domain.Account {
 	return accounts
 }
 
-func fetchAccountsConcurrently(ctx context.Context, app *app, accounts []domain.Account, errWriter io.Writer) error {
+func fetchAccountsConcurrently(ctx context.Context, app *app, accounts []domain.Account) (fetchSummary, error) {
 	const maxConcurrent = 5
 	results := make(chan fetchResult, len(accounts))
 	semaphore := make(chan struct{}, maxConcurrent)
@@ -166,36 +209,42 @@ func fetchAccountsConcurrently(ctx context.Context, app *app, accounts []domain.
 		close(results)
 	}()
 
-	var successes []domain.AccountID
-	var failures []fetchResult
+	summary := fetchSummary{
+		successes: make([]domain.AccountID, 0, len(accounts)),
+		failures:  make([]fetchResult, 0, len(accounts)),
+	}
 
 	for result := range results {
 		if result.err == nil {
-			successes = append(successes, result.accountID)
+			summary.successes = append(summary.successes, result.accountID)
 		} else {
-			failures = append(failures, result)
+			summary.failures = append(summary.failures, result)
 		}
 	}
 
-	if len(failures) > 0 {
-		fmt.Fprintln(errWriter, "\nFailed to fetch:")
-		for _, failure := range failures {
-			fmt.Fprintf(errWriter, "  - %v\n", failure.err)
-		}
-	}
-
-	if len(failures) == len(accounts) {
+	if len(summary.failures) == len(accounts) {
 		if len(accounts) == 1 {
-			return failures[0].err
+			return summary, summary.failures[0].err
 		}
-		return fmt.Errorf("all accounts failed to fetch")
+		return summary, fmt.Errorf("all accounts failed to fetch")
 	}
 
-	if len(successes) > 0 && len(failures) > 0 {
-		fmt.Fprintf(errWriter, "\n%d/%d accounts updated successfully\n", len(successes), len(accounts))
+	return summary, nil
+}
+
+func writeFetchSummaryPlain(errWriter io.Writer, summary fetchSummary) {
+	if errWriter == nil || !summary.hasFailures() {
+		return
 	}
 
-	return nil
+	fmt.Fprintln(errWriter, "\nFailed to fetch:")
+	for _, failure := range summary.failures {
+		fmt.Fprintf(errWriter, "  - %v\n", failure.err)
+	}
+
+	if len(summary.successes) > 0 {
+		fmt.Fprintf(errWriter, "\n%d/%d accounts updated successfully\n", len(summary.successes), len(summary.successes)+len(summary.failures))
+	}
 }
 
 func fetchAndPersistLimits(ctx context.Context, app *app, account domain.Account) error {

--- a/cmd/usage_test.go
+++ b/cmd/usage_test.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/bnema/openai-accounts-cli/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type errWriter struct {
+	err error
+}
+
+func (w errWriter) Write(_ []byte) (int, error) {
+	return 0, w.err
+}
+
+func TestFetchAccountsConcurrentlyWithNoAccounts(t *testing.T) {
+	summary, err := fetchAccountsConcurrently(context.Background(), nil, nil)
+	require.NoError(t, err)
+	assert.Empty(t, summary.successes)
+	assert.Empty(t, summary.failures)
+}
+
+func TestWriteFetchSummaryPlainReturnsWriterError(t *testing.T) {
+	writeErr := errors.New("broken pipe")
+	summary := fetchSummary{
+		failures: []fetchResult{{
+			accountID: domain.AccountID("acc-1"),
+			err:       errors.New("boom"),
+		}},
+	}
+
+	err := writeFetchSummaryPlain(errWriter{err: writeErr}, summary)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, writeErr)
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -12,6 +12,10 @@ func newVersionCmd() *cobra.Command {
 		Use:   "version",
 		Short: "Print version information",
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if wantsJSON(cmd) {
+				return writeJSONOutput(cmd, map[string]string{"version": version.Version})
+			}
+
 			_, err := fmt.Fprintln(cmd.OutOrStdout(), version.Version)
 			return err
 		},

--- a/docs/noctalia-plugin-contract.md
+++ b/docs/noctalia-plugin-contract.md
@@ -1,0 +1,112 @@
+# Noctalia plugin contract
+
+## First release scope
+
+The first Noctalia plugin release should expose:
+
+- a panel with the current account snapshot
+- the current recommended account for sync
+- one-click sync actions for `opencode`, `codex`, `pi`, and `all`
+- a small bar widget that opens the panel and shows recommendation state
+- IPC actions for `togglePanel`, `refresh`, and `sync`
+
+Launcher-provider search can wait until the panel workflow feels solid.
+
+## Existing CLI commands safe for direct plugin use
+
+These commands already have stable enough success/error envelopes for the plugin:
+
+- `oa sync opencode --json`
+- `oa sync codex --json`
+- `oa sync pi --json`
+- `oa sync --all --json`
+- `oa version --json`
+
+These commands are useful for humans, but not ideal as the main plugin contract:
+
+- `oa usage --json` / `oa status --json` — returns raw Go status structs
+- `oa auth check --json` — diagnostic-oriented, not a panel snapshot
+- `oa account list --json` — too small on its own for the plugin UI
+
+## Gap closed for Noctalia
+
+Use the dedicated snapshot command instead of raw status JSON:
+
+- `oa noctalia snapshot --json`
+- `oa noctalia snapshot --json --refresh`
+
+This command keeps recommendation and eligibility logic in Go and returns warnings in stdout JSON, so QML only renders and triggers actions.
+
+## Snapshot DTO v1
+
+```json
+{
+  "schema_version": 1,
+  "generated_at": "2026-05-23T12:10:00Z",
+  "refreshed": true,
+  "refresh_command": ["noctalia", "snapshot", "--json", "--refresh"],
+  "recommendation": {
+    "available": true,
+    "account_id": "acc-3",
+    "account_name": "Best",
+    "rank": 1,
+    "message": "recommended account: Best"
+  },
+  "accounts": [
+    {
+      "id": "acc-3",
+      "name": "Best",
+      "provider": "openai",
+      "model": "gpt-5",
+      "plan_type": "pro",
+      "auth_method": "chatgpt",
+      "auth_configured": true,
+      "recommendation": {
+        "rank": 1,
+        "selected": true,
+        "eligible": true
+      },
+      "daily": {
+        "percent_used": 21,
+        "percent_remaining": 79,
+        "resets_at": "2026-05-23T17:00:00Z",
+        "captured_at": "2026-05-23T12:10:00Z"
+      },
+      "weekly": {
+        "percent_used": 47,
+        "percent_remaining": 53,
+        "resets_at": "2026-05-30T17:00:00Z",
+        "captured_at": "2026-05-23T12:10:00Z"
+      },
+      "subscription": {
+        "active_start": "2026-05-01T00:00:00Z",
+        "active_until": "2026-06-01T00:00:00Z",
+        "will_renew": true,
+        "billing_period": "monthly",
+        "billing_currency": "USD",
+        "is_delinquent": false,
+        "captured_at": "2026-05-23T12:10:00Z"
+      }
+    }
+  ],
+  "sync_targets": [
+    { "id": "opencode", "label": "OpenCode", "command": ["sync", "opencode", "--json"] },
+    { "id": "codex", "label": "Codex", "command": ["sync", "codex", "--json"] },
+    { "id": "pi", "label": "Pi", "command": ["sync", "pi", "--json"] },
+    { "id": "all", "label": "All", "command": ["sync", "--all", "--json"] }
+  ],
+  "warnings": [
+    {
+      "account_id": "acc-2",
+      "message": "account acc-2: refresh oauth tokens after unauthorized usage response: ..."
+    }
+  ]
+}
+```
+
+## Contract rules
+
+- `schema_version` is mandatory and must change on breaking DTO changes.
+- warnings belong in stdout JSON, not stderr, for snapshot reads.
+- sync actions are discovered from `sync_targets[*].command`.
+- QML may format labels, but must not reimplement recommendation or account-selection rules.

--- a/docs/noctalia-plugin-contract.md
+++ b/docs/noctalia-plugin-contract.md
@@ -108,5 +108,5 @@ This command keeps recommendation and eligibility logic in Go and returns warnin
 
 - `schema_version` is mandatory and must change on breaking DTO changes.
 - warnings belong in stdout JSON, not stderr, for snapshot reads.
-- sync actions are discovered from `sync_targets[*].command`.
+- sync actions are discovered from `sync_targets[*].command`; the plugin should treat snapshot `sync_targets` as authoritative instead of hardcoding its own target list.
 - QML may format labels, but must not reimplement recommendation or account-selection rules.

--- a/plugins/noctalia/oa-accounts/BarWidget.qml
+++ b/plugins/noctalia/oa-accounts/BarWidget.qml
@@ -1,0 +1,48 @@
+import QtQuick
+import Quickshell
+import qs.Commons
+
+Item {
+    id: root
+
+    property var pluginApi: null
+    property ShellScreen screen
+    property string widgetId: ""
+    property string section: ""
+    property int sectionWidgetIndex: -1
+    property int sectionWidgetsCount: 0
+
+    implicitWidth: Style.capsuleHeight
+    implicitHeight: Style.capsuleHeight
+
+    Rectangle {
+        anchors.fill: parent
+        radius: Style.radiusL
+        color: mouseArea.containsMouse ? Color.mHover : Style.capsuleColor
+
+        Image {
+            anchors.centerIn: parent
+            source: Qt.resolvedUrl("icons/bot.svg")
+            sourceSize.width: 18
+            sourceSize.height: 18
+            width: 18
+            height: 18
+            smooth: true
+        }
+
+    }
+
+    MouseArea {
+        id: mouseArea
+
+        anchors.fill: parent
+        hoverEnabled: true
+        cursorShape: Qt.PointingHandCursor
+        onClicked: {
+            if (pluginApi && pluginApi.openPanel)
+                pluginApi.openPanel(root.screen, root);
+
+        }
+    }
+
+}

--- a/plugins/noctalia/oa-accounts/LimitBar.qml
+++ b/plugins/noctalia/oa-accounts/LimitBar.qml
@@ -1,0 +1,108 @@
+import QtQuick
+import QtQuick.Layouts
+import qs.Commons
+import qs.Widgets
+
+Item {
+    id: root
+
+    property string label: ""
+    property var limitData: null
+    property color accentColor: Color.mPrimary
+
+    function remainingPercent() {
+        if (!limitData || limitData.percent_remaining === undefined)
+            return 0;
+
+        return Math.max(0, Math.min(100, Math.round(limitData.percent_remaining)));
+    }
+
+    function progressRatio() {
+        return remainingPercent() / 100;
+    }
+
+    function summaryText() {
+        if (!limitData)
+            return "Unavailable";
+
+        return `${remainingPercent()}% remaining`;
+    }
+
+    function resetText() {
+        if (!limitData || !limitData.resets_at)
+            return "reset unknown";
+
+        const at = new Date(limitData.resets_at);
+        if (isNaN(at.getTime()))
+            return "reset unknown";
+
+        return at.toLocaleString(undefined, {
+            "weekday": "short",
+            "hour": "2-digit",
+            "minute": "2-digit"
+        });
+    }
+
+    implicitHeight: content.implicitHeight
+
+    ColumnLayout {
+        id: content
+
+        anchors.fill: parent
+        spacing: Style.marginXS
+
+        RowLayout {
+            Layout.fillWidth: true
+
+            NText {
+                text: root.label
+                pointSize: Style.fontSizeS
+                font.weight: Font.Medium
+                color: Color.mOnSurface
+            }
+
+            Item {
+                Layout.fillWidth: true
+            }
+
+            NText {
+                text: root.summaryText()
+                pointSize: Style.fontSizeS
+                color: Color.mOnSurfaceVariant
+            }
+
+        }
+
+        Rectangle {
+            Layout.fillWidth: true
+            implicitHeight: Style.marginM
+            radius: implicitHeight / 2
+            color: Qt.alpha(Color.mOnSurface, 0.12)
+
+            Rectangle {
+                width: parent.width * root.progressRatio()
+                height: parent.height
+                radius: parent.radius
+                color: root.limitData ? root.accentColor : Qt.alpha(Color.mOnSurfaceVariant, 0.4)
+
+                Behavior on width {
+                    NumberAnimation {
+                        duration: 180
+                        easing.type: Easing.OutCubic
+                    }
+
+                }
+
+            }
+
+        }
+
+        NText {
+            text: root.resetText()
+            pointSize: Style.fontSizeXS
+            color: Color.mOnSurfaceVariant
+        }
+
+    }
+
+}

--- a/plugins/noctalia/oa-accounts/Main.qml
+++ b/plugins/noctalia/oa-accounts/Main.qml
@@ -7,15 +7,12 @@ Item {
     property var pluginApi: null
     property var service
 
-    service: OAAccountsService {
-        id: serviceInstance
-    }
-
     Component.onCompleted: {
         if (pluginApi)
             service.start(pluginApi);
 
     }
+
     IpcHandler {
         function togglePanel() {
             if (!pluginApi || !pluginApi.withCurrentScreen)
@@ -35,6 +32,10 @@ Item {
         }
 
         target: "plugin:oa-accounts"
+    }
+
+    service: OAAccountsService {
+        id: serviceInstance
     }
 
 }

--- a/plugins/noctalia/oa-accounts/Main.qml
+++ b/plugins/noctalia/oa-accounts/Main.qml
@@ -7,11 +7,14 @@ Item {
     property var pluginApi: null
     property var service
 
-    Component.onCompleted: {
-        if (pluginApi)
+    function startServiceIfReady() {
+        if (pluginApi && service && service.pluginApi !== pluginApi)
             service.start(pluginApi);
 
     }
+
+    onPluginApiChanged: startServiceIfReady()
+    Component.onCompleted: startServiceIfReady()
 
     IpcHandler {
         function togglePanel() {

--- a/plugins/noctalia/oa-accounts/Main.qml
+++ b/plugins/noctalia/oa-accounts/Main.qml
@@ -1,0 +1,40 @@
+import QtQuick
+import Quickshell.Io
+
+Item {
+    id: root
+
+    property var pluginApi: null
+    property var service
+
+    service: OAAccountsService {
+        id: serviceInstance
+    }
+
+    Component.onCompleted: {
+        if (pluginApi)
+            service.start(pluginApi);
+
+    }
+    IpcHandler {
+        function togglePanel() {
+            if (!pluginApi || !pluginApi.withCurrentScreen)
+                return ;
+
+            pluginApi.withCurrentScreen((screen) => {
+                return pluginApi.togglePanel(screen);
+            });
+        }
+
+        function refresh() {
+            service.refresh(true);
+        }
+
+        function sync(targetId: string) {
+            service.syncTarget(targetId);
+        }
+
+        target: "plugin:oa-accounts"
+    }
+
+}

--- a/plugins/noctalia/oa-accounts/OAAccountsService.qml
+++ b/plugins/noctalia/oa-accounts/OAAccountsService.qml
@@ -79,6 +79,21 @@ Item {
         }
     }
 
+    function normalizeWarnings(items) {
+        if (!items || !items.length)
+            return [];
+
+        return items.map((item) => {
+            const warning = item || {
+            };
+            const message = warning.message || warning.error || "";
+            return Object.assign({
+            }, warning, {
+                "message": message
+            });
+        });
+    }
+
     function applySnapshot(parsed) {
         snapshot = parsed || ({
         });
@@ -88,7 +103,7 @@ Item {
         });
         accounts = parsed && parsed.accounts ? parsed.accounts : [];
         syncTargets = parsed && parsed.sync_targets ? parsed.sync_targets : defaultSyncTargets();
-        warnings = parsed && parsed.warnings ? parsed.warnings : [];
+        warnings = normalizeWarnings(parsed && parsed.warnings ? parsed.warnings : []);
         lastUpdated = parsed && parsed.generated_at ? parsed.generated_at : "";
         errorText = "";
     }
@@ -187,7 +202,7 @@ Item {
                 const accountName = parsed.account_name || parsed.account_id || "selected account";
                 actionText = `Synced ${pendingActionLabel} using ${accountName}`;
                 if (parsed.warnings)
-                    warnings = parsed.warnings;
+                    warnings = normalizeWarnings(parsed.warnings);
 
                 refreshTimer.restart();
                 refresh(false);

--- a/plugins/noctalia/oa-accounts/OAAccountsService.qml
+++ b/plugins/noctalia/oa-accounts/OAAccountsService.qml
@@ -1,0 +1,233 @@
+import QtQuick
+import Quickshell.Io
+
+Item {
+    id: root
+
+    property var pluginApi: null
+    property var snapshot: ({
+    })
+    property var recommendation: ({
+        "available": false,
+        "message": "No data yet"
+    })
+    property var accounts: []
+    property var syncTargets: []
+    property var warnings: []
+    property bool loading: false
+    property bool actionRunning: false
+    property string errorText: ""
+    property string actionText: ""
+    property string lastUpdated: ""
+    property string pendingActionLabel: ""
+    readonly property bool hasRecommendation: recommendation && recommendation.available === true
+    readonly property string recommendationLabel: hasRecommendation ? (recommendation.account_name || recommendation.account_id) : ((recommendation && recommendation.message) || "No recommended account")
+    readonly property string binaryPath: {
+        if (pluginApi && pluginApi.pluginSettings && pluginApi.pluginSettings.binaryPath)
+            return pluginApi.pluginSettings.binaryPath;
+
+        if (pluginApi && pluginApi.manifest && pluginApi.manifest.metadata && pluginApi.manifest.metadata.defaultSettings && pluginApi.manifest.metadata.defaultSettings.binaryPath)
+            return pluginApi.manifest.metadata.defaultSettings.binaryPath;
+
+        return "oa";
+    }
+    readonly property int refreshIntervalSeconds: {
+        if (pluginApi && pluginApi.pluginSettings && pluginApi.pluginSettings.refreshIntervalSeconds)
+            return pluginApi.pluginSettings.refreshIntervalSeconds;
+
+        if (pluginApi && pluginApi.manifest && pluginApi.manifest.metadata && pluginApi.manifest.metadata.defaultSettings && pluginApi.manifest.metadata.defaultSettings.refreshIntervalSeconds)
+            return pluginApi.manifest.metadata.defaultSettings.refreshIntervalSeconds;
+
+        return 300;
+    }
+    readonly property bool refreshOnLoad: {
+        if (pluginApi && pluginApi.pluginSettings && pluginApi.pluginSettings.refreshOnLoad !== undefined)
+            return pluginApi.pluginSettings.refreshOnLoad;
+
+        if (pluginApi && pluginApi.manifest && pluginApi.manifest.metadata && pluginApi.manifest.metadata.defaultSettings && pluginApi.manifest.metadata.defaultSettings.refreshOnLoad !== undefined)
+            return pluginApi.manifest.metadata.defaultSettings.refreshOnLoad;
+
+        return true;
+    }
+
+    function start(api) {
+        pluginApi = api;
+        refresh(refreshOnLoad);
+        refreshTimer.running = true;
+    }
+
+    function defaultSyncTargets() {
+        return [{
+            "id": "opencode",
+            "label": "OpenCode",
+            "command": ["sync", "opencode", "--json"]
+        }, {
+            "id": "codex",
+            "label": "Codex",
+            "command": ["sync", "codex", "--json"]
+        }, {
+            "id": "pi",
+            "label": "Pi",
+            "command": ["sync", "pi", "--json"]
+        }, {
+            "id": "all",
+            "label": "All",
+            "command": ["sync", "--all", "--json"]
+        }];
+    }
+
+    function snapshotCommand(forceRefresh) {
+        const args = [binaryPath, "noctalia", "snapshot", "--json"];
+        if (forceRefresh)
+            args.push("--refresh");
+
+        return args;
+    }
+
+    function parseJSON(text, fallbackValue) {
+        try {
+            if (!text || text.trim() === "")
+                return fallbackValue;
+
+            return JSON.parse(text);
+        } catch (error) {
+            return fallbackValue;
+        }
+    }
+
+    function applySnapshot(parsed) {
+        snapshot = parsed || ({
+        });
+        recommendation = parsed && parsed.recommendation ? parsed.recommendation : ({
+            "available": false,
+            "message": "No recommendation"
+        });
+        accounts = parsed && parsed.accounts ? parsed.accounts : [];
+        syncTargets = parsed && parsed.sync_targets ? parsed.sync_targets : defaultSyncTargets();
+        warnings = parsed && parsed.warnings ? parsed.warnings : [];
+        lastUpdated = parsed && parsed.generated_at ? parsed.generated_at : "";
+        errorText = "";
+    }
+
+    function refresh(forceRefresh) {
+        if (snapshotProcess.running)
+            return ;
+
+        loading = true;
+        errorText = "";
+        snapshotProcess.command = snapshotCommand(forceRefresh);
+        snapshotProcess.running = true;
+    }
+
+    function syncTarget(targetId) {
+        if (actionProcess.running)
+            return ;
+
+        const target = resolveSyncTarget(targetId);
+        if (!target) {
+            errorText = `Unknown sync target: ${targetId}`;
+            return ;
+        }
+        pendingActionLabel = target.label || target.id || targetId;
+        errorText = "";
+        actionText = "";
+        actionRunning = true;
+        actionProcess.command = [binaryPath].concat(target.command || []);
+        actionProcess.running = true;
+    }
+
+    function resolveSyncTarget(targetId) {
+        const targets = syncTargets && syncTargets.length ? syncTargets : defaultSyncTargets();
+        for (const target of targets) {
+            if (target.id === targetId)
+                return target;
+
+        }
+        return null;
+    }
+
+    function processErrorText(rawText, exitCode) {
+        const parsed = parseJSON(rawText, null);
+        if (parsed && parsed.error)
+            return parsed.error;
+
+        if (rawText && rawText.trim() !== "")
+            return rawText.trim();
+
+        return `oa command failed (exit ${exitCode})`;
+    }
+
+    visible: false
+
+    Process {
+        id: snapshotProcess
+
+        running: false
+        onExited: function(exitCode) {
+            loading = false;
+            if (exitCode === 0) {
+                const parsed = root.parseJSON(snapshotStdout.text, null);
+                if (parsed === null) {
+                    errorText = "Failed to parse oa snapshot JSON";
+                    return ;
+                }
+                applySnapshot(parsed);
+                return ;
+            }
+            errorText = processErrorText(snapshotStderr.text, exitCode);
+        }
+
+        stdout: StdioCollector {
+            id: snapshotStdout
+        }
+
+        stderr: StdioCollector {
+            id: snapshotStderr
+        }
+
+    }
+
+    Process {
+        id: actionProcess
+
+        running: false
+        onExited: function(exitCode) {
+            actionRunning = false;
+            if (exitCode === 0) {
+                const parsed = root.parseJSON(actionStdout.text, {
+                });
+                if (parsed.ok === false) {
+                    errorText = parsed.error || `Failed to sync ${pendingActionLabel}`;
+                    return ;
+                }
+                const accountName = parsed.account_name || parsed.account_id || "selected account";
+                actionText = `Synced ${pendingActionLabel} using ${accountName}`;
+                if (parsed.warnings)
+                    warnings = parsed.warnings;
+
+                refresh(false);
+                return ;
+            }
+            errorText = processErrorText(actionStderr.text, exitCode);
+        }
+
+        stdout: StdioCollector {
+            id: actionStdout
+        }
+
+        stderr: StdioCollector {
+            id: actionStderr
+        }
+
+    }
+
+    Timer {
+        id: refreshTimer
+
+        interval: refreshIntervalSeconds * 1000
+        running: false
+        repeat: true
+        onTriggered: root.refresh(true)
+    }
+
+}

--- a/plugins/noctalia/oa-accounts/OAAccountsService.qml
+++ b/plugins/noctalia/oa-accounts/OAAccountsService.qml
@@ -57,23 +57,7 @@ Item {
     }
 
     function defaultSyncTargets() {
-        return [{
-            "id": "opencode",
-            "label": "OpenCode",
-            "command": ["sync", "opencode", "--json"]
-        }, {
-            "id": "codex",
-            "label": "Codex",
-            "command": ["sync", "codex", "--json"]
-        }, {
-            "id": "pi",
-            "label": "Pi",
-            "command": ["sync", "pi", "--json"]
-        }, {
-            "id": "all",
-            "label": "All",
-            "command": ["sync", "--all", "--json"]
-        }];
+        return snapshot && snapshot.sync_targets ? snapshot.sync_targets : [];
     }
 
     function snapshotCommand(forceRefresh) {
@@ -196,8 +180,8 @@ Item {
             if (exitCode === 0) {
                 const parsed = root.parseJSON(actionStdout.text, {
                 });
-                if (parsed.ok === false) {
-                    errorText = parsed.error || `Failed to sync ${pendingActionLabel}`;
+                if (!(parsed && parsed.ok === true)) {
+                    errorText = parsed && parsed.error ? parsed.error : `Failed to sync ${pendingActionLabel}`;
                     return ;
                 }
                 const accountName = parsed.account_name || parsed.account_id || "selected account";
@@ -205,6 +189,7 @@ Item {
                 if (parsed.warnings)
                     warnings = parsed.warnings;
 
+                refreshTimer.restart();
                 refresh(false);
                 return ;
             }

--- a/plugins/noctalia/oa-accounts/Panel.qml
+++ b/plugins/noctalia/oa-accounts/Panel.qml
@@ -1,0 +1,400 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import qs.Commons
+import qs.Widgets
+
+Item {
+    id: root
+
+    property var pluginApi: null
+    property var service: pluginApi && pluginApi.mainInstance ? pluginApi.mainInstance.service : null
+    readonly property var geometryPlaceholder: panelContainer
+    readonly property bool allowAttach: true
+    property real contentPreferredWidth: 420 * Style.uiScaleRatio
+    property real contentPreferredHeight: Math.min(680 * Style.uiScaleRatio, panelContent.implicitHeight + Style.marginL * 2)
+
+    function formatPercent(limit) {
+        if (!limit)
+            return "—";
+
+        return `${Math.round(limit.percent_remaining)}% remaining`;
+    }
+
+    function formatReset(limit) {
+        if (!limit || !limit.resets_at)
+            return "reset unknown";
+
+        const at = new Date(limit.resets_at);
+        return isNaN(at.getTime()) ? "reset unknown" : `resets ${at.toLocaleString()}`;
+    }
+
+    function formatUpdated(value) {
+        if (!value)
+            return "never";
+
+        const at = new Date(value);
+        return isNaN(at.getTime()) ? "never" : at.toLocaleString();
+    }
+
+    function hasRenewableSubscription(account) {
+        if (!account || !account.subscription || !account.subscription.active_until)
+            return false;
+
+        const renewalAt = new Date(account.subscription.active_until);
+        return !isNaN(renewalAt.getTime()) && renewalAt.getFullYear() > 1;
+    }
+
+    function visibleAccounts() {
+        const accounts = service && service.accounts ? service.accounts : [];
+        return accounts.filter((account) => {
+            return root.hasRenewableSubscription(account);
+        });
+    }
+
+    anchors.fill: parent
+
+    Rectangle {
+        id: panelContainer
+
+        anchors.fill: parent
+        color: "transparent"
+
+        ScrollView {
+            anchors.fill: parent
+            anchors.margins: Style.marginL
+            clip: true
+
+            ColumnLayout {
+                id: panelContent
+
+                width: panelContainer.width - Style.marginL * 2
+                spacing: Style.marginM
+
+                Rectangle {
+                    Layout.fillWidth: true
+                    color: "transparent"
+                    implicitHeight: headerLayout.implicitHeight
+
+                    RowLayout {
+                        id: headerLayout
+
+                        anchors.fill: parent
+                        spacing: Style.marginS
+
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+
+                            NText {
+                                text: "OpenAI Accounts"
+                                pointSize: Style.fontSizeL
+                                font.weight: Font.DemiBold
+                                color: Color.mOnSurface
+                            }
+
+                            NText {
+                                text: service && service.loading ? "Refreshing snapshot…" : `Updated ${root.formatUpdated(service ? service.lastUpdated : "")}`
+                                pointSize: Style.fontSizeS
+                                color: Color.mOnSurfaceVariant
+                            }
+
+                        }
+
+                        NButton {
+                            icon: "refresh"
+                            text: service && service.loading ? "Refreshing" : "Refresh"
+                            enabled: !!service && !service.loading
+                            onClicked: service.refresh(true)
+                        }
+
+                        NIconButton {
+                            icon: "x"
+                            onClicked: {
+                                if (pluginApi && pluginApi.closePanel)
+                                    pluginApi.closePanel(pluginApi.panelOpenScreen);
+
+                            }
+                        }
+
+                    }
+
+                }
+
+                Rectangle {
+                    Layout.fillWidth: true
+                    radius: Style.radiusL
+                    color: Style.capsuleColor
+                    border.color: Color.mOutline
+                    border.width: 1
+                    implicitHeight: recommendationLayout.implicitHeight + Style.marginM * 2
+
+                    ColumnLayout {
+                        id: recommendationLayout
+
+                        anchors.fill: parent
+                        anchors.margins: Style.marginM
+                        spacing: Style.marginS
+
+                        NText {
+                            text: "Recommendation"
+                            pointSize: Style.fontSizeM
+                            font.weight: Font.Medium
+                            color: Color.mOnSurface
+                        }
+
+                        NText {
+                            text: service ? service.recommendationLabel || "No snapshot yet" : "No snapshot yet"
+                            pointSize: Style.fontSizeL
+                            color: service && service.hasRecommendation ? Color.mPrimary : Color.mOnSurface
+                        }
+
+                        NText {
+                            text: service && service.recommendation ? service.recommendation.message || "" : ""
+                            visible: text !== ""
+                            pointSize: Style.fontSizeS
+                            color: Color.mOnSurfaceVariant
+                        }
+
+                    }
+
+                }
+
+                Rectangle {
+                    Layout.fillWidth: true
+                    visible: !!(service && service.errorText)
+                    radius: Style.radiusL
+                    color: "transparent"
+                    border.color: Color.mTertiary
+                    border.width: 1
+                    implicitHeight: errorTextItem.implicitHeight + Style.marginM * 2
+
+                    NText {
+                        id: errorTextItem
+
+                        anchors.fill: parent
+                        anchors.margins: Style.marginM
+                        text: service ? service.errorText || "" : ""
+                        wrapMode: Text.Wrap
+                        pointSize: Style.fontSizeS
+                        color: Color.mTertiary
+                    }
+
+                }
+
+                Rectangle {
+                    Layout.fillWidth: true
+                    visible: !!(service && service.actionText)
+                    radius: Style.radiusL
+                    color: "transparent"
+                    border.color: Color.mPrimary
+                    border.width: 1
+                    implicitHeight: actionTextItem.implicitHeight + Style.marginM * 2
+
+                    NText {
+                        id: actionTextItem
+
+                        anchors.fill: parent
+                        anchors.margins: Style.marginM
+                        text: service ? service.actionText || "" : ""
+                        wrapMode: Text.Wrap
+                        pointSize: Style.fontSizeS
+                        color: Color.mPrimary
+                    }
+
+                }
+
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    spacing: Style.marginS
+
+                    NText {
+                        text: "Sync targets"
+                        pointSize: Style.fontSizeM
+                        font.weight: Font.Medium
+                        color: Color.mOnSurface
+                    }
+
+                    Flow {
+                        Layout.fillWidth: true
+                        spacing: Style.marginS
+
+                        Repeater {
+                            model: service ? service.syncTargets || [] : []
+
+                            delegate: NButton {
+                                required property var modelData
+
+                                text: modelData.label
+                                enabled: !!service && !service.actionRunning
+                                onClicked: service.syncTarget(modelData.id)
+                            }
+
+                        }
+
+                    }
+
+                }
+
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    spacing: Style.marginS
+                    visible: (service && service.warnings ? service.warnings : []).length > 0
+
+                    NText {
+                        text: "Warnings"
+                        pointSize: Style.fontSizeM
+                        font.weight: Font.Medium
+                        color: Color.mOnSurface
+                    }
+
+                    Repeater {
+                        model: service ? service.warnings || [] : []
+
+                        delegate: Rectangle {
+                            required property var modelData
+
+                            Layout.fillWidth: true
+                            radius: Style.radiusL
+                            color: "transparent"
+                            border.color: Color.mOutline
+                            border.width: 1
+                            implicitHeight: warningLayout.implicitHeight + Style.marginM * 2
+
+                            ColumnLayout {
+                                id: warningLayout
+
+                                anchors.fill: parent
+                                anchors.margins: Style.marginM
+                                spacing: 2
+
+                                NText {
+                                    text: modelData.account_id || "account"
+                                    pointSize: Style.fontSizeS
+                                    font.weight: Font.Medium
+                                    color: Color.mOnSurface
+                                }
+
+                                NText {
+                                    text: modelData.message || ""
+                                    wrapMode: Text.Wrap
+                                    pointSize: Style.fontSizeS
+                                    color: Color.mOnSurfaceVariant
+                                }
+
+                            }
+
+                        }
+
+                    }
+
+                }
+
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    spacing: Style.marginS
+
+                    NText {
+                        text: "Accounts"
+                        pointSize: Style.fontSizeM
+                        font.weight: Font.Medium
+                        color: Color.mOnSurface
+                    }
+
+                    Repeater {
+                        model: root.visibleAccounts()
+
+                        delegate: Rectangle {
+                            required property var modelData
+
+                            Layout.fillWidth: true
+                            radius: Style.radiusL
+                            color: Style.capsuleColor
+                            border.color: modelData.recommendation && modelData.recommendation.selected ? Color.mPrimary : Color.mOutline
+                            border.width: 1
+                            implicitHeight: accountLayout.implicitHeight + Style.marginM * 2
+
+                            ColumnLayout {
+                                id: accountLayout
+
+                                anchors.fill: parent
+                                anchors.margins: Style.marginM
+                                spacing: Style.marginS
+
+                                RowLayout {
+                                    Layout.fillWidth: true
+
+                                    ColumnLayout {
+                                        Layout.fillWidth: true
+                                        spacing: 2
+
+                                        NText {
+                                            text: modelData.name || modelData.id
+                                            pointSize: Style.fontSizeM
+                                            font.weight: Font.Medium
+                                            color: Color.mOnSurface
+                                        }
+
+                                        NText {
+                                            text: `${modelData.id} • ${modelData.plan_type || modelData.model || "unknown plan"}`
+                                            pointSize: Style.fontSizeS
+                                            color: Color.mOnSurfaceVariant
+                                        }
+
+                                    }
+
+                                    NText {
+                                        text: modelData.recommendation && modelData.recommendation.selected ? "Recommended" : ((modelData.recommendation && modelData.recommendation.eligible) ? "Eligible" : "Unavailable")
+                                        pointSize: Style.fontSizeS
+                                        color: modelData.recommendation && modelData.recommendation.selected ? Color.mPrimary : Color.mOnSurfaceVariant
+                                    }
+
+                                }
+
+                                NText {
+                                    text: `Auth: ${modelData.auth_method || "none"}${modelData.auth_configured ? "" : " (not configured)"}`
+                                    pointSize: Style.fontSizeS
+                                    color: Color.mOnSurfaceVariant
+                                }
+
+                                NText {
+                                    text: `Daily: ${root.formatPercent(modelData.daily)} • ${root.formatReset(modelData.daily)}`
+                                    pointSize: Style.fontSizeS
+                                    color: Color.mOnSurface
+                                }
+
+                                NText {
+                                    text: `Weekly: ${root.formatPercent(modelData.weekly)} • ${root.formatReset(modelData.weekly)}`
+                                    pointSize: Style.fontSizeS
+                                    color: Color.mOnSurface
+                                }
+
+                                NText {
+                                    visible: !!modelData.subscription
+                                    text: modelData.subscription ? `Subscription until ${root.formatUpdated(modelData.subscription.active_until)}` : ""
+                                    pointSize: Style.fontSizeS
+                                    color: Color.mOnSurfaceVariant
+                                }
+
+                            }
+
+                        }
+
+                    }
+
+                    NText {
+                        visible: root.visibleAccounts().length === 0
+                        text: "No subscribed accounts to display"
+                        pointSize: Style.fontSizeS
+                        color: Color.mOnSurfaceVariant
+                    }
+
+                }
+
+            }
+
+        }
+
+    }
+
+}

--- a/plugins/noctalia/oa-accounts/Panel.qml
+++ b/plugins/noctalia/oa-accounts/Panel.qml
@@ -52,8 +52,7 @@ Item {
             return false;
 
         const renewalAt = new Date(account.subscription.active_until);
-        const validSubscriptionCutoff = new Date("1970-01-02T00:00:00Z");
-        return !isNaN(renewalAt.getTime()) && renewalAt >= validSubscriptionCutoff;
+        return !isNaN(renewalAt.getTime()) && renewalAt > new Date();
     }
 
     function visibleAccounts() {

--- a/plugins/noctalia/oa-accounts/Panel.qml
+++ b/plugins/noctalia/oa-accounts/Panel.qml
@@ -39,12 +39,21 @@ Item {
         return `Updated ${deltaDays} day${deltaDays === 1 ? "" : "s"} ago`;
     }
 
+    function formatAbsoluteDate(value) {
+        if (!value)
+            return "unknown date";
+
+        const at = new Date(value);
+        return isNaN(at.getTime()) ? "unknown date" : at.toLocaleString();
+    }
+
     function hasRenewableSubscription(account) {
         if (!account || !account.subscription || !account.subscription.active_until)
             return false;
 
         const renewalAt = new Date(account.subscription.active_until);
-        return !isNaN(renewalAt.getTime()) && renewalAt.getFullYear() > 1;
+        const validSubscriptionCutoff = new Date("1970-01-02T00:00:00Z");
+        return !isNaN(renewalAt.getTime()) && renewalAt >= validSubscriptionCutoff;
     }
 
     function visibleAccounts() {
@@ -391,7 +400,7 @@ Item {
                                 NText {
                                     visible: !!modelData.subscription
                                     Layout.fillWidth: true
-                                    text: modelData.subscription ? `Subscription until ${root.formatUpdated(modelData.subscription.active_until)}` : ""
+                                    text: modelData.subscription ? `Subscription until ${root.formatAbsoluteDate(modelData.subscription.active_until)}` : ""
                                     wrapMode: Text.Wrap
                                     pointSize: Style.fontSizeS
                                     color: Color.mOnSurfaceVariant

--- a/plugins/noctalia/oa-accounts/Panel.qml
+++ b/plugins/noctalia/oa-accounts/Panel.qml
@@ -13,28 +13,30 @@ Item {
     readonly property bool allowAttach: true
     property real contentPreferredWidth: 420 * Style.uiScaleRatio
     property real contentPreferredHeight: Math.min(680 * Style.uiScaleRatio, panelContent.implicitHeight + Style.marginL * 2)
-
-    function formatPercent(limit) {
-        if (!limit)
-            return "—";
-
-        return `${Math.round(limit.percent_remaining)}% remaining`;
-    }
-
-    function formatReset(limit) {
-        if (!limit || !limit.resets_at)
-            return "reset unknown";
-
-        const at = new Date(limit.resets_at);
-        return isNaN(at.getTime()) ? "reset unknown" : `resets ${at.toLocaleString()}`;
-    }
+    property double nowMs: Date.now()
 
     function formatUpdated(value) {
         if (!value)
-            return "never";
+            return "Updated never";
 
         const at = new Date(value);
-        return isNaN(at.getTime()) ? "never" : at.toLocaleString();
+        if (isNaN(at.getTime()))
+            return "Updated never";
+
+        const deltaMs = Math.max(0, root.nowMs - at.getTime());
+        const deltaMinutes = Math.floor(deltaMs / 60000);
+        if (deltaMinutes < 1)
+            return "Updated just now";
+
+        if (deltaMinutes < 60)
+            return `Updated ${deltaMinutes} minute${deltaMinutes === 1 ? "" : "s"} ago`;
+
+        const deltaHours = Math.floor(deltaMinutes / 60);
+        if (deltaHours < 24)
+            return `Updated ${deltaHours} hour${deltaHours === 1 ? "" : "s"} ago`;
+
+        const deltaDays = Math.floor(deltaHours / 24);
+        return `Updated ${deltaDays} day${deltaDays === 1 ? "" : "s"} ago`;
     }
 
     function hasRenewableSubscription(account) {
@@ -53,6 +55,21 @@ Item {
     }
 
     anchors.fill: parent
+
+    Timer {
+        interval: 60000
+        running: true
+        repeat: true
+        onTriggered: root.nowMs = Date.now()
+    }
+
+    Connections {
+        function onLastUpdatedChanged() {
+            root.nowMs = Date.now();
+        }
+
+        target: service
+    }
 
     Rectangle {
         id: panelContainer
@@ -94,7 +111,7 @@ Item {
                             }
 
                             NText {
-                                text: service && service.loading ? "Refreshing snapshot…" : `Updated ${root.formatUpdated(service ? service.lastUpdated : "")}`
+                                text: service && service.loading ? "Refreshing snapshot…" : root.formatUpdated(service ? service.lastUpdated : "")
                                 pointSize: Style.fontSizeS
                                 color: Color.mOnSurfaceVariant
                             }
@@ -357,21 +374,25 @@ Item {
                                     color: Color.mOnSurfaceVariant
                                 }
 
-                                NText {
-                                    text: `Daily: ${root.formatPercent(modelData.daily)} • ${root.formatReset(modelData.daily)}`
-                                    pointSize: Style.fontSizeS
-                                    color: Color.mOnSurface
+                                LimitBar {
+                                    Layout.fillWidth: true
+                                    label: "Daily"
+                                    limitData: modelData.daily
+                                    accentColor: Color.mPrimary
                                 }
 
-                                NText {
-                                    text: `Weekly: ${root.formatPercent(modelData.weekly)} • ${root.formatReset(modelData.weekly)}`
-                                    pointSize: Style.fontSizeS
-                                    color: Color.mOnSurface
+                                LimitBar {
+                                    Layout.fillWidth: true
+                                    label: "Weekly"
+                                    limitData: modelData.weekly
+                                    accentColor: Color.mSecondary
                                 }
 
                                 NText {
                                     visible: !!modelData.subscription
+                                    Layout.fillWidth: true
                                     text: modelData.subscription ? `Subscription until ${root.formatUpdated(modelData.subscription.active_until)}` : ""
+                                    wrapMode: Text.Wrap
                                     pointSize: Style.fontSizeS
                                     color: Color.mOnSurfaceVariant
                                 }

--- a/plugins/noctalia/oa-accounts/Panel.qml
+++ b/plugins/noctalia/oa-accounts/Panel.qml
@@ -52,7 +52,7 @@ Item {
             return false;
 
         const renewalAt = new Date(account.subscription.active_until);
-        return !isNaN(renewalAt.getTime()) && renewalAt > new Date();
+        return !isNaN(renewalAt.getTime()) && renewalAt.getTime() > root.nowMs;
     }
 
     function visibleAccounts() {

--- a/plugins/noctalia/oa-accounts/README.md
+++ b/plugins/noctalia/oa-accounts/README.md
@@ -1,0 +1,36 @@
+# OpenAI Accounts for Noctalia
+
+Companion Noctalia plugin for `oa`.
+
+## Local install
+
+Build or install the CLI first:
+
+```bash
+go install ./cmd/oa
+```
+
+Install the plugin locally with a symlink:
+
+```bash
+mkdir -p ~/.config/noctalia/plugins
+ln -sfn /absolute/path/to/openai-accounts-cli/plugins/noctalia/oa-accounts ~/.config/noctalia/plugins/oa-accounts
+```
+
+Then:
+
+1. restart or reload Noctalia
+2. enable **OpenAI Accounts** in the plugin manager if it is disabled
+3. add the plugin's bar widget to your bar
+4. click the widget to open the panel
+
+## CLI contract used
+
+- `oa noctalia snapshot --json`
+- `oa noctalia snapshot --json --refresh`
+- `oa sync opencode --json`
+- `oa sync codex --json`
+- `oa sync pi --json`
+- `oa sync --all --json`
+
+The QML layer only renders the snapshot and triggers returned sync commands.

--- a/plugins/noctalia/oa-accounts/README.md
+++ b/plugins/noctalia/oa-accounts/README.md
@@ -4,7 +4,7 @@ Companion Noctalia plugin for `oa`.
 
 ## Local install
 
-Build or install the CLI first:
+Build or install the CLI first from the repository root:
 
 ```bash
 go install ./cmd/oa
@@ -14,7 +14,8 @@ Install the plugin locally with a symlink:
 
 ```bash
 mkdir -p ~/.config/noctalia/plugins
-ln -sfn /absolute/path/to/openai-accounts-cli/plugins/noctalia/oa-accounts ~/.config/noctalia/plugins/oa-accounts
+PLUGIN_DIR="$(realpath plugins/noctalia/oa-accounts)"
+ln -sfn "$PLUGIN_DIR" ~/.config/noctalia/plugins/oa-accounts
 ```
 
 Then:

--- a/plugins/noctalia/oa-accounts/icons/bot.svg
+++ b/plugins/noctalia/oa-accounts/icons/bot.svg
@@ -1,0 +1,18 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#f6c190"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M12 8V4H8" />
+  <rect width="16" height="12" x="4" y="8" rx="2" />
+  <path d="M2 14h2" />
+  <path d="M20 14h2" />
+  <path d="M15 13v2" />
+  <path d="M9 13v2" />
+</svg>

--- a/plugins/noctalia/oa-accounts/manifest.json
+++ b/plugins/noctalia/oa-accounts/manifest.json
@@ -1,0 +1,30 @@
+{
+  "id": "oa-accounts",
+  "name": "OpenAI Accounts",
+  "version": "0.1.0",
+  "minNoctaliaVersion": "3.6.0",
+  "author": "Brice / oa",
+  "license": "MIT",
+  "repository": "https://github.com/bnema/openai-accounts-cli",
+  "description": "Show the recommended oa account and trigger sync actions from Noctalia.",
+  "tags": [
+    "Bar",
+    "Panel",
+    "Development"
+  ],
+  "entryPoints": {
+    "main": "Main.qml",
+    "barWidget": "BarWidget.qml",
+    "panel": "Panel.qml"
+  },
+  "dependencies": {
+    "plugins": []
+  },
+  "metadata": {
+    "defaultSettings": {
+      "binaryPath": "oa",
+      "refreshIntervalSeconds": 300,
+      "refreshOnLoad": true
+    }
+  }
+}


### PR DESCRIPTION
This pull request introduces comprehensive support for JSON output across the CLI, making the tool more scriptable and robust for automation. It adds a new `json_output.go` utility, refactors command handlers to use structured JSON responses and errors, and updates the documentation. Additionally, it introduces instructions for a Noctalia plugin. Below are the most important changes:

**JSON Output and Error Handling Improvements:**

* Added a new `cmd/json_output.go` file, which centralizes logic for detecting JSON output requests (`--json`), writing JSON responses, and formatting errors in JSON. This enables consistent machine-readable output and error handling across all commands.
* Refactored all relevant command handlers (in `cmd/account.go`, `cmd/auth.go`, `cmd/login.go`, and `cmd/auth_check.go`) to use the new JSON output utilities. Commands now return structured JSON for both success and error cases when `--json` is specified. [[1]](diffhunk://#diff-2f59846146e430f2a075e4a9771fa64aa474e53edadeab5f6c43c961f1bc8b6cR14-R19) [[2]](diffhunk://#diff-2f59846146e430f2a075e4a9771fa64aa474e53edadeab5f6c43c961f1bc8b6cL31-R48) [[3]](diffhunk://#diff-2f59846146e430f2a075e4a9771fa64aa474e53edadeab5f6c43c961f1bc8b6cL51-R71) [[4]](diffhunk://#diff-2a99768a3ac5c528aaefcdbcfc65b406d9913e150e08dab88cfbeacdd19793a8R14-R19) [[5]](diffhunk://#diff-2a99768a3ac5c528aaefcdbcfc65b406d9913e150e08dab88cfbeacdd19793a8L33-R65) [[6]](diffhunk://#diff-2a99768a3ac5c528aaefcdbcfc65b406d9913e150e08dab88cfbeacdd19793a8L68-R93) [[7]](diffhunk://#diff-5a74178be41677fb9978809a94df96bd5ba861fbc92f130c8bd3ae07cd10973bR30-R79) [[8]](diffhunk://#diff-5a74178be41677fb9978809a94df96bd5ba861fbc92f130c8bd3ae07cd10973bR92-R132) [[9]](diffhunk://#diff-4e497e80de2b0f5468ea1ef74dc7ed5e6eaa10c8808c8a463878a9a9ec79799dR16-R21) [[10]](diffhunk://#diff-4e497e80de2b0f5468ea1ef74dc7ed5e6eaa10c8808c8a463878a9a9ec79799dL32-R38) [[11]](diffhunk://#diff-4e497e80de2b0f5468ea1ef74dc7ed5e6eaa10c8808c8a463878a9a9ec79799dL52-R60) [[12]](diffhunk://#diff-4e497e80de2b0f5468ea1ef74dc7ed5e6eaa10c8808c8a463878a9a9ec79799dL66-R81) [[13]](diffhunk://#diff-4e497e80de2b0f5468ea1ef74dc7ed5e6eaa10c8808c8a463878a9a9ec79799dL88-R107) [[14]](diffhunk://#diff-4e497e80de2b0f5468ea1ef74dc7ed5e6eaa10c8808c8a463878a9a9ec79799dL106-R118) [[15]](diffhunk://#diff-4e497e80de2b0f5468ea1ef74dc7ed5e6eaa10c8808c8a463878a9a9ec79799dL117-R138)

**Command Behavior Enhancements:**

* Improved top-level command behavior to provide helpful error messages or JSON errors when subcommands are missing, increasing usability and consistency. [[1]](diffhunk://#diff-2f59846146e430f2a075e4a9771fa64aa474e53edadeab5f6c43c961f1bc8b6cR14-R19) [[2]](diffhunk://#diff-2a99768a3ac5c528aaefcdbcfc65b406d9913e150e08dab88cfbeacdd19793a8R14-R19) [[3]](diffhunk://#diff-4e497e80de2b0f5468ea1ef74dc7ed5e6eaa10c8808c8a463878a9a9ec79799dR16-R21)

**Documentation and Plugin Support:**

* Updated `README.md` to add installation instructions for the Noctalia plugin, and clarified build/install commands for developers. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L23-R23) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R140-L145)

These changes make the CLI friendlier for integration with other tools and UIs, and pave the way for improved plugin support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Consistent machine-readable JSON output across CLI commands (errors, status, login, auth, sync, version) and a new noctalia snapshot/sync-friendly interface
  * Added Noctalia companion plugin with panel, bar widget, usage/limits display, and one-click sync targets

* **Documentation**
  * Updated install/development instructions to use direct Go build/install
  * Added Noctalia plugin guide and plugin contract spec

* **Tests**
  * Expanded CLI tests for JSON output and error responses

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bnema/openai-accounts-cli/pull/4?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->